### PR TITLE
Add order dice

### DIFF
--- a/Beastmen.cat
+++ b/Beastmen.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="495c-99bf-3793-41ba" name="Beastmen" revision="1" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="495c-99bf-3793-41ba" name="Beastmen" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d341-7808-1528-80dd" name="Centaur Lord" hidden="false" collective="false" targetId="eebd-c5bd-500d-1128" type="selectionEntry"/>
     <entryLink id="5920-ac53-718c-9dba" name="Minotaur Lord" hidden="false" collective="false" targetId="ec37-7732-2e11-9c4a" type="selectionEntry"/>
@@ -19,6 +19,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="eebd-c5bd-500d-1128" name="Centaur Lord" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="560e-175e-30ee-8a1d" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -37,6 +40,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -53,6 +57,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8191-ed28-15fe-4939" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -61,6 +66,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6639-f58f-fd9e-7f95" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -69,6 +75,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3ad5-73f4-2cb9-4d5e" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -77,6 +84,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -92,6 +100,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="257e-5776-82de-edaf" name="Ranged Magic Weapons" hidden="false" collective="false" type="upgrade">
@@ -107,6 +116,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="cd2f-2ee1-9c8d-ae90" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -115,6 +125,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8b86-33bb-680c-9377" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -123,6 +134,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -130,6 +142,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -145,6 +158,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -157,6 +171,7 @@
             <selectionEntry id="9c7f-08a9-b243-14e7" name="Savage" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -172,6 +187,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="245c-597b-ebbd-8c79" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -180,6 +196,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d31-1b9e-ac37-0383" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -188,6 +205,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5c86-96d7-7226-1844" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -196,6 +214,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c810-20ff-6395-e97a" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -204,6 +223,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8e23-0119-f5d3-cc26" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -212,6 +232,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5170-b6f8-9436-2430" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -220,6 +241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -227,9 +249,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="52.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ec37-7732-2e11-9c4a" name="Minotaur Lord" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc22-bd2b-b3b7-2331" type="max"/>
       </constraints>
@@ -260,6 +286,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="66.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -267,6 +294,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a85b-bdd1-8049-ff8f" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -286,6 +314,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="76.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -293,6 +322,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -309,6 +339,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5f1-c16f-0aa0-a683" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -317,6 +348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0900-d64c-d274-edfe" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -325,6 +357,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30f8-d758-a278-36b2" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -333,6 +366,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78a8-4b52-3b32-77fc" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -341,6 +375,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="069e-7f63-a7be-ca08" name="Bloomin Big Axe" hidden="false" collective="false" type="upgrade">
@@ -349,6 +384,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1987-f299-6bb6-28ad" name="Magic Weapon" hidden="false" collective="false" type="upgrade">
@@ -364,6 +400,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b73d-2764-cbef-b258" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -372,6 +409,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c538-7361-eb84-68f9" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -380,6 +418,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3df2-58f8-0243-3aed" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -388,6 +427,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="72d1-d8bf-ac8e-2044" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -396,6 +436,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fc8b-eb76-8231-90b2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -404,6 +445,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="588c-7afc-75d7-459b" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -412,6 +454,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -419,6 +462,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -435,6 +479,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b558-c63a-65e4-b13e" name="Irresistible Charge" hidden="false" collective="false" type="upgrade">
@@ -443,6 +488,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -458,6 +504,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -465,9 +512,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a878-9926-c79b-52f9" name="Beastman Guard" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d512-74a1-8db4-8b9d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -492,6 +543,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="91a7-c477-55e2-ca33" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -505,6 +557,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -512,6 +565,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="123c-8f08-a41b-a4d9" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -528,6 +582,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="dc2c-1804-1e25-0ec4" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -541,6 +596,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -548,6 +604,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -564,6 +621,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="426b-f70f-042c-454a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -572,6 +630,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18f3-c91c-b03b-bf0e" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -580,6 +639,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a1f6-3522-9eea-fe6d" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -595,6 +655,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="671b-8e4c-0a6a-f24f" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -603,6 +664,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -625,6 +687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -632,9 +695,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="09df-5d39-3dd7-ebd4" name="Beastman Warriors" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="079c-502a-44fe-2257" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -659,6 +726,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e340-d92c-e18b-dea6" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -672,6 +740,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -679,6 +748,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4e0a-2fb3-0822-21c8" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -695,6 +765,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8126-4076-bd74-ccab" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -708,6 +779,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -715,6 +787,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -731,6 +804,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="611d-26f9-0216-a406" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -739,6 +813,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5682-4851-d858-93e4" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -747,6 +822,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b1c7-0ba8-9d8d-afc2" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -762,6 +838,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="caf0-ac47-d61c-a87e" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -770,6 +847,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -792,6 +870,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -799,9 +878,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8306-d0be-5ab8-5c90" name="Low Beastman Warriors" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="8cd2-d288-bd09-9bb2" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -826,6 +909,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0ffc-c050-5c94-8614" name="Low Beastman Warrior Leader" hidden="false" collective="false" type="model">
@@ -839,6 +923,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -846,6 +931,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2625-0cb2-db95-f8f5" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -862,6 +948,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1521-d702-cafa-92cd" name="Low Beastman Warrior Leader" hidden="false" collective="false" type="model">
@@ -875,6 +962,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -882,6 +970,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -905,6 +994,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1464-a592-9f11-5c94" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -920,6 +1010,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30e3-95ee-424d-463a" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -935,6 +1026,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebd3-7c54-caea-c0f7" name="Clubs" hidden="false" collective="false" type="upgrade">
@@ -943,6 +1035,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -950,9 +1043,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="48b1-55f2-458e-7da3" name="Low Beastman Archers" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="88b3-9f1e-e217-d3d9" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -967,6 +1064,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -984,6 +1082,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5b7-faa2-99aa-cc48" name="Low Beastman Archer" hidden="false" collective="false" type="model">
@@ -996,6 +1095,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1019,6 +1119,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="09fa-14dd-6651-f785" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1034,6 +1135,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88ad-2da9-7dab-e3da" name="Clubs" hidden="false" collective="false" type="upgrade">
@@ -1042,6 +1144,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1049,9 +1152,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="229d-a488-92e7-b61c" name="Minotaurs" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="aff1-bead-b023-5d06" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -1069,6 +1176,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88a5-d308-2eed-67dd" name="Minotaur Champion" hidden="false" collective="false" type="model">
@@ -1083,6 +1191,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1099,6 +1208,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89d4-b366-5c21-5532" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1107,6 +1217,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="887a-7031-a813-625f" name="Bloomin Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1122,6 +1233,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1138,6 +1250,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9864-7e05-45d1-df5b" name="Irresistible Charge" hidden="false" collective="false" type="upgrade">
@@ -1153,6 +1266,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1160,9 +1274,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="99f4-211b-3162-038d" name="Beast Hounds" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="fb3f-a4ba-fcc1-9771" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
         <categoryLink id="e7d4-f5c6-295a-47a7" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1178,10 +1296,11 @@
               <infoLinks>
                 <infoLink id="8bb4-9512-9fb2-6515" name="Beast Hounds" hidden="false" targetId="b590-eb52-39a5-587a" type="profile"/>
                 <infoLink id="57cc-d2e7-e549-07fe" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
-                <infoLink id="a47c-57f8-31ef-3cd9" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                <infoLink id="a47c-57f8-31ef-3cd9" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1201,6 +1320,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1217,6 +1337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9883-770c-0e26-69f9" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1225,6 +1346,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1247,10 +1369,11 @@
                       <infoLinks>
                         <infoLink id="b5ba-1655-3a2e-3de7" name="Pack Master" hidden="false" targetId="1d03-5868-0a88-efa4" type="profile"/>
                         <infoLink id="9b78-894f-0c27-0dc0" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                        <infoLink id="b401-8789-f7db-ddc8" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                        <infoLink id="b401-8789-f7db-ddc8" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1258,6 +1381,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="43ac-cc6b-b21b-7d80" name="Pack Master in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1272,10 +1396,11 @@
                       <infoLinks>
                         <infoLink id="2807-6214-fa5f-1a5c" name="Pack Master in Medium Armour" hidden="false" targetId="6291-460b-8fd8-be34" type="profile"/>
                         <infoLink id="e5e4-0e06-26d4-f4cf" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                        <infoLink id="794c-407a-976f-09f7" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                        <infoLink id="794c-407a-976f-09f7" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1283,6 +1408,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1290,9 +1416,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e6ed-5b98-5c6a-7096" name="Centaurs" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="dd9a-2934-8da9-aade" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -1317,6 +1447,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b2de-1d26-3518-f6f0" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -1330,6 +1461,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="44.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1337,6 +1469,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2064-340b-bfba-e4c0" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1353,6 +1486,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6ffa-4ea8-4436-941e" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -1366,6 +1500,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="46.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1373,6 +1508,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0a42-7c7f-0e0e-ad1c" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1389,6 +1525,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="36.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9dba-b719-22a8-18dc" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -1402,6 +1539,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="48.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1409,6 +1547,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1425,6 +1564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="21b9-5061-e069-c829" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -1440,6 +1580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf7e-df25-d805-31dc" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1455,6 +1596,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c94e-d5ef-a2f4-42e3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1470,6 +1612,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4832-7fa7-cf23-be91" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -1485,6 +1628,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1507,6 +1651,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1522,6 +1667,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1529,9 +1675,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="18b6-72e8-624b-489a" name="Harpies" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="4f86-0b14-d18e-3e21" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1550,6 +1700,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1565,6 +1716,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1587,6 +1739,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1594,9 +1747,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="67f5-eb29-60ba-e402" name="Beastman Bolt Thrower" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="ff30-a715-e4df-e017" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -1613,6 +1770,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bbc-ff85-f34f-c7fb" name="Beastman Crew" hidden="false" collective="false" type="model">
@@ -1625,6 +1783,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1641,6 +1800,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e981-6fa8-87ab-99d4" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1649,6 +1809,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1665,6 +1826,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3995-525a-7cc0-9494" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -1673,6 +1835,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1680,9 +1843,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8605-371b-3b15-4600" name="Beastman Chieftain" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="a862-20e7-8392-0907" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="ed2a-3bf2-5e2f-04a8" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1701,6 +1868,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="80.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="994f-b68f-0164-d6a3" name="Beastman Bodyguard" hidden="false" collective="false" type="model">
@@ -1713,6 +1881,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1729,6 +1898,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90d8-bd28-17a1-8ba1" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1737,6 +1907,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="70a9-d90a-0657-cb1e" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -1745,6 +1916,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c77a-5258-0c60-eb7d" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1753,6 +1925,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1769,6 +1942,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3241-012a-1440-e53d" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1777,6 +1951,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b42-ca29-f289-f3b5" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1785,6 +1960,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1801,6 +1977,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a281-bfd7-9d59-ef5d" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1809,6 +1986,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1832,6 +2010,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1847,6 +2026,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7258-496c-012b-4adb" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1855,6 +2035,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0db0-83a8-347d-8543" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1863,6 +2044,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8659-a62f-9569-8fa4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1871,6 +2053,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="24aa-5ea6-22d4-db99" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1879,6 +2062,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cff6-6dea-13bb-acd2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1887,6 +2071,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="20ae-e372-6022-2cfc" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1895,6 +2080,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1902,9 +2088,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0fe7-f569-45ac-b1df" name="Beastman Chieftain in Chariot" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="57b3-a1a2-5336-ecff" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="683f-34ff-b931-046e" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
@@ -1922,6 +2112,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="631f-5c61-c79f-9d93" name="Beastman Chieftain" hidden="false" collective="false" type="model">
@@ -1936,6 +2127,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="166.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d794-06af-fcfc-3fe5" name="Chariot" hidden="false" collective="false" type="upgrade">
@@ -1952,6 +2144,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1968,6 +2161,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff4c-410f-1334-001a" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1976,6 +2170,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c6aa-12d4-1f9b-239e" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1984,6 +2179,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7fb5-7476-d2df-8b81" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1992,6 +2188,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2008,6 +2205,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8a43-3db2-f216-b65c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2016,6 +2214,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d0f-b441-03e5-b9cb" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -2024,6 +2223,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2039,6 +2239,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2055,6 +2256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29ef-7b9c-9f4b-53f6" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2063,6 +2265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2086,6 +2289,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2101,6 +2305,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f859-065a-1b0d-36d1" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2109,6 +2314,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6866-8134-56e2-9b4f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2117,6 +2323,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02ff-462c-7bd4-dda9" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2125,6 +2332,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="60f7-3d48-d995-aaad" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2133,6 +2341,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6bf-a7f6-ab86-954e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2141,6 +2350,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7632-c3c1-d859-b9fa" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2149,6 +2359,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2156,9 +2367,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f4ae-d5fd-7d7d-7001" name="Beastman Shaman" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9d24-e284-748b-6b9a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="8dc7-00dc-1b07-78e1" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
@@ -2178,6 +2393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2191,16 +2407,19 @@
             <selectionEntry id="0a1a-8204-4493-83f9" name="Magic Level 1" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c26f-75e3-6fba-f6ba" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de6e-06c7-8cc9-fe80" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2223,6 +2442,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2252,11 +2472,13 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="13.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d908-3a05-3a53-2198" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2271,11 +2493,13 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="15.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2283,6 +2507,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6d39-0600-70c9-0078" name="Spirit Guide or Familiar" hidden="false" collective="false" type="upgrade">
@@ -2299,6 +2524,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2306,6 +2532,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2321,6 +2548,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dc26-4813-9f27-2cb6" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2332,6 +2560,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee12-1783-a93d-3c9e" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2343,6 +2572,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5934-e2cb-9775-cb90" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2354,6 +2584,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed09-ac42-8f78-3b4b" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2365,6 +2596,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0654-7129-936f-cb5f" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2376,6 +2608,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a141-1e19-e7dc-23ea" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2387,6 +2620,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fced-a0e1-eec9-6ef8" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2398,6 +2632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="92bc-4c47-f81f-142f" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2409,6 +2644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b829-9a59-07c3-4ec3" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2420,6 +2656,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91fe-a6d8-45c9-4bbd" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2431,6 +2668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b32-0d70-0c5b-598c" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2442,6 +2680,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a13a-fcaa-35e0-a128" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2453,6 +2692,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e28c-8fd7-1cb3-6fbc" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2464,6 +2704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2480,6 +2721,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d99-5a52-b681-233c" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2488,6 +2730,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="871a-e506-76da-f7b3" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2496,6 +2739,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c84-6172-7bb8-e63b" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2504,6 +2748,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="441a-3676-3700-6364" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2512,6 +2757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fff7-9886-42bf-7f53" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2520,6 +2766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d0c8-da64-786f-eced" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2528,6 +2775,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6600-b242-d0d4-dd19" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2536,6 +2784,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="604d-9f2d-2d7d-87d6" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2544,6 +2793,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af35-89ba-8b23-de5f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2552,6 +2802,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7f0f-5247-026c-6a9a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2560,6 +2811,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="40c8-3e5d-6acf-d17b" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2568,6 +2820,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="512a-1df6-69a3-c735" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2576,6 +2829,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0996-90b0-3594-8553" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2584,6 +2838,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2599,6 +2854,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="984a-ffd3-3276-758f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2607,6 +2863,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8c19-03ce-0e96-c8c7" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2615,6 +2872,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8676-f3bc-3f23-528e" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2623,6 +2881,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="deac-b18e-64b1-cb60" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2631,6 +2890,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9acc-6cfe-a338-613e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2639,6 +2899,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed9e-c016-78f4-80f4" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2647,6 +2908,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2654,9 +2916,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f46f-c1d1-3df5-62dc" name="Beastman Shaman in Chariot" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="15dd-1f9d-5f63-9f54" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
         <categoryLink id="3286-24eb-7a25-19e2" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
@@ -2681,6 +2947,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="148.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bfe0-8281-1337-e4dc" name="Beastman Crew" hidden="false" collective="false" type="model">
@@ -2693,6 +2960,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2706,16 +2974,19 @@
             <selectionEntry id="fbcb-9050-e962-5e4a" name="Magic Level 1" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d432-ae84-9d12-5a0a" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d3fd-047d-dc28-2605" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2731,6 +3002,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2750,6 +3022,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2766,6 +3039,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e47e-9adb-c20e-9276" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -2774,6 +3048,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2787,11 +3062,13 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f08c-0970-935e-33ba" name="Additional Spell" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2808,6 +3085,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7324-ffce-42e5-c07c" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2816,6 +3094,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="830c-dba6-2cc8-aa3a" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2824,6 +3103,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ecd-d085-25cf-1775" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2832,6 +3112,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af0e-bfb5-a111-1912" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2840,6 +3121,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa46-5a1e-34d6-ad31" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2848,6 +3130,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1885-1784-05c7-7c8b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2856,6 +3139,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6b1-9828-8546-4a87" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2864,6 +3148,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="baaf-4802-dbab-fc40" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2872,6 +3157,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a5d-15f5-d1a7-a7e9" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2880,6 +3166,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df5d-34a3-8e11-1360" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2888,6 +3175,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c21a-25dc-07e0-65d4" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2896,6 +3184,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e83-c4b7-9e10-95c7" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2904,6 +3193,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5559-9de3-e1b9-49db" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2912,6 +3202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2927,6 +3218,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c4f-4465-f076-487a" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2938,6 +3230,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0204-e123-2de6-f650" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2949,6 +3242,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d54f-916f-0314-5449" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2960,6 +3254,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c80-1b2e-21e2-c730" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2971,6 +3266,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e7e9-8499-3de9-848e" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2982,6 +3278,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="85c1-cbd6-fc72-4416" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2993,6 +3290,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b438-6732-2255-08ec" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -3004,6 +3302,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9d1e-2d68-a1de-0b92" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -3015,6 +3314,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73c1-9a09-134f-383c" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -3026,6 +3326,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e07-bae3-f2e0-e767" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -3037,6 +3338,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e793-f567-f39f-9780" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -3048,6 +3350,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="76b0-bfce-578b-0169" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -3059,6 +3362,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c213-1e50-9ed0-05d3" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -3070,6 +3374,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3085,6 +3390,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f92f-be44-041a-4db7" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -3093,6 +3399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b051-3351-9086-002f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -3101,6 +3408,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5770-6d44-04fd-f4ce" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -3109,6 +3417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="002e-afe1-43e4-8f95" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -3117,6 +3426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b09c-db48-6ae6-40c0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -3125,6 +3435,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="49d3-94d1-217d-8a78" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -3133,6 +3444,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3140,6 +3452,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -3408,7 +3721,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHTH SV3</characteristic>
       </characteristics>
     </profile>
-    <profile id="3f6d-528f-fde9-a9f7" name="Chariot Scythes" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="3f6d-528f-fde9-a9f7" name="Chariot Scythes" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">D6 SV1 Impact hits on Charge</characteristic>

--- a/Dwarfs.cat
+++ b/Dwarfs.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3b46-1dfa-75fc-f98f" name="Dwarfs" revision="1" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3b46-1dfa-75fc-f98f" name="Dwarfs" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="6dbd-0ad3-a92f-c7f6" name="Dwarf Lord" hidden="false" collective="false" targetId="c721-3183-d63d-d213" type="selectionEntry"/>
     <entryLink id="68b2-8587-0f02-6bc9" name="Dwarf Runesmith [81 pts]" hidden="false" collective="false" targetId="c40e-98bb-55a2-ca4c" type="selectionEntry"/>
@@ -22,6 +22,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="c721-3183-d63d-d213" name="Dwarf Lord [87 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="3150-2ae0-b3a7-dfe9" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="091e-879b-f9f5-3246" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -43,6 +46,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="86b3-51c0-74b9-d290" name="Bloomin Big Axes" hidden="false" collective="false" type="upgrade">
@@ -58,6 +62,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b6c-f559-7abe-9f67" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -66,6 +71,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -88,6 +94,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -104,6 +111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da24-0bc6-b820-f473" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -112,6 +120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -128,6 +137,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="894d-371e-c5ad-4372" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -136,6 +146,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -160,6 +171,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="82.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5989-181d-8651-3f65" name="Dwarf Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -172,6 +184,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -179,6 +192,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6a71-aabb-c1b4-5401" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
@@ -196,6 +210,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="91.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0476-19e4-21f0-6208" name="Dwarf Bodyguard in Heavy Armour" hidden="false" collective="false" type="model">
@@ -208,6 +223,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -215,6 +231,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -230,6 +247,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4c3d-e8d5-ab5d-100c" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -238,6 +256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="574e-d74e-cd44-886f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -246,6 +265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4527-eefa-999e-58e0" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -254,6 +274,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e57c-bc5a-db83-b243" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -262,6 +283,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="77a9-85f5-e1b0-25aa" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -270,6 +292,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dafd-fc76-27a9-2707" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -278,6 +301,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -285,9 +309,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c40e-98bb-55a2-ca4c" name="Dwarf Runesmith [81 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="35d3-b106-1a67-064f" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="5c48-c938-3c5a-408d" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
@@ -305,6 +333,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d113-18d9-f23c-454e" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -313,6 +342,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3364-d3a7-35f6-d38d" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -321,6 +351,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -337,6 +368,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6817-4901-87fc-f085" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -345,6 +377,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -361,6 +394,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99c1-8b8d-ac0a-4af9" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -369,6 +403,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -386,6 +421,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a315-0a3e-9a26-e5f1" name="Apprentice Runesmith" hidden="false" collective="false" type="model">
@@ -397,6 +433,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -419,6 +456,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -434,6 +472,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9bcf-b631-0b0d-9a5a" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -445,6 +484,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e87-2e4b-6418-d573" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -456,6 +496,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a624-77ca-be20-6432" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -467,6 +508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="593c-bc90-96fa-23df" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -478,6 +520,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f393-cade-edf1-a4c8" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -489,6 +532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0189-f869-65dc-1f2b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -500,6 +544,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="57b2-ff8e-b26e-16f1" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -511,6 +556,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2558-5c4d-c2bf-d8d1" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -522,6 +568,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbe7-0c59-a463-f3c2" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -533,6 +580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3153-e1ca-ffac-5a0c" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -544,6 +592,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96a5-5cc4-3ebc-b95e" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -555,6 +604,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d84e-820e-ea50-bfe5" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -566,6 +616,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e1bd-a535-d0e0-b121" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -577,6 +628,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -593,6 +645,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="72c5-67b6-fabc-52d8" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -601,6 +654,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ccd-a11d-e9c4-2ed1" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -609,6 +663,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a22d-b502-dd76-78dc" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -617,6 +672,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4265-52e6-b76f-20e2" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -625,6 +681,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a559-df7d-526f-1a25" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -633,6 +690,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff05-fa81-4367-6180" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -641,6 +699,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5aa2-83e5-5e79-1f53" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -649,6 +708,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d8ac-7bfa-f5b5-d4ac" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -657,6 +717,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6772-4143-fd80-1c8f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -665,6 +726,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="122d-7e13-00ff-0b71" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -673,6 +735,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ceca-8f2b-16f5-a042" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -681,6 +744,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c6d7-4bfb-d5e0-0ba0" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -689,6 +753,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="744e-e030-9c59-cb11" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -697,6 +762,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -712,6 +778,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d8af-af6d-34d6-5aff" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -720,6 +787,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="783f-c219-f28f-a2df" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -728,6 +796,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="041e-fffd-f288-6a39" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -736,6 +805,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bec5-e879-7936-d0a3" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -744,6 +814,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="37f5-81a7-f3df-0459" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -752,6 +823,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="46a1-2e6f-8f21-70b1" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -760,6 +832,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -767,9 +840,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a6db-bd48-1d3e-8292" name="Dwarf Hero [86 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="7aa9-16f7-1283-d9cf" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
       </infoLinks>
@@ -788,6 +865,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -804,6 +882,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c138-df81-da8d-a098" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -812,6 +891,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -828,6 +908,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3739-8036-7b0e-927a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -836,6 +917,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aaa7-9443-7dae-5b41" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -844,6 +926,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -859,6 +942,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -874,6 +958,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -890,6 +975,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3f51-bc10-6c09-45fd" name="Dwarf Hero in Heavy Armour" hidden="false" collective="false" type="model">
@@ -898,6 +984,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3bcb-bb94-69eb-1ecf" name="Dwarf Hero, Crazed Psychotic (No Armour)" hidden="false" collective="false" type="model">
@@ -907,6 +994,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="87.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -923,6 +1011,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ecd8-da49-612a-346f" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -931,6 +1020,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -946,6 +1036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="151c-0ab7-5d64-317f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -954,6 +1045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d4d4-97cc-5deb-c714" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -962,6 +1054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="38a5-33b9-6e86-006d" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -970,6 +1063,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="768d-fa50-7f62-6bee" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -978,6 +1072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d54-8e25-ed90-c245" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -986,6 +1081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="efc0-dd43-2732-bbd8" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -994,6 +1090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1001,9 +1098,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3737-797e-c49a-bd2e" name="Dwarf Guard [115 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="f1ee-3612-a118-2e94" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
       </infoLinks>
@@ -1024,6 +1125,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7242-cd1b-74f6-b8b3" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1032,6 +1134,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1058,6 +1161,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4d9c-08b7-f862-57b1" name="Dwarf Guard" hidden="false" collective="false" type="model">
@@ -1070,6 +1174,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1077,6 +1182,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eac7-0b3a-cf5b-613f" name="Dwarf Guard in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1094,6 +1200,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3be7-e411-54a5-9a80" name="Dwarf Guard" hidden="false" collective="false" type="model">
@@ -1106,6 +1213,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1113,6 +1221,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1120,9 +1229,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0af2-4120-b7ef-ed73" name="Dwarf Warriors [100 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="1565-f8fe-ea4f-7b8d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1149,6 +1262,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4b27-6479-27fd-2189" name="Dwarf Warrior" hidden="false" collective="false" type="model">
@@ -1161,6 +1275,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1168,6 +1283,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="683e-3a8b-10c4-b24f" name="Dwarf Warriors in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1185,6 +1301,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1243-0fc6-7980-34af" name="Dwarf Warrior" hidden="false" collective="false" type="model">
@@ -1197,6 +1314,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1204,6 +1322,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1228,6 +1347,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04c0-2158-168c-2d02" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1236,6 +1356,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3faa-e697-9a05-083f" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1244,6 +1365,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bf3a-d27a-e592-1111" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1252,6 +1374,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fd7b-549b-3973-848d" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1271,6 +1394,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1278,9 +1402,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0120-dc29-e7a3-7a46" name="Dwarf Archers [100 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="16ac-b9d5-d590-94a3" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
       </infoLinks>
@@ -1309,6 +1437,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a89b-cfbb-18f7-dbb8" name="Dwarf Archer" hidden="false" collective="false" type="model">
@@ -1321,6 +1450,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1328,6 +1458,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a70-2217-86dc-03f0" name="Dwarf Archers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1345,6 +1476,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="159b-b450-bbc9-884e" name="Dwarf Archer" hidden="false" collective="false" type="model">
@@ -1357,6 +1489,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1364,6 +1497,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1380,6 +1514,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="69af-eb55-a24d-4267" name="Crossbow" hidden="false" collective="false" type="upgrade">
@@ -1395,6 +1530,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1402,9 +1538,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8600-3664-2ff7-0154" name="Dwarf Handgunners [110 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="4201-3261-ac27-eeff" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
         <infoLink id="b68e-0da9-b61a-5dad" name="Handgun" hidden="false" targetId="c6ac-d307-29c2-4ef1" type="profile"/>
@@ -1434,6 +1574,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="09c3-0f1d-0c79-6ffb" name="Dwarf Handgunner" hidden="false" collective="false" type="model">
@@ -1446,6 +1587,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1453,6 +1595,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1660-d9da-eeee-93e1" name="Dwarf Handgunners in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1470,6 +1613,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2359-0904-458a-8915" name="Dwarf Handgunner" hidden="false" collective="false" type="model">
@@ -1482,6 +1626,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1489,6 +1634,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1496,9 +1642,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c3c0-1daa-695f-77ce" name="Dwarf Pony Riders [70 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="034b-4146-4c27-d7fa" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -1527,6 +1677,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="bc3d-f58e-d8f9-5f05" name="Dwarf Pony Rider" hidden="false" collective="false" type="model">
@@ -1539,6 +1690,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1546,6 +1698,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8814-e0ea-0db2-a3bc" name="Dwarf Pony Riders in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1563,6 +1716,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1641-820c-099b-fe0d" name="Dwarf Pony Rider" hidden="false" collective="false" type="model">
@@ -1575,6 +1729,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1582,6 +1737,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1598,6 +1754,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9a6f-73f6-31c6-02ba" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1606,6 +1763,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1613,9 +1771,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ce6-e262-f72d-7f94" name="Dwarf Rangers [112 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="d842-da47-74cd-3826" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
         <infoLink id="b625-ac56-05f4-ffe3" name="Vengeful" hidden="false" targetId="5e63-c99b-00b4-24eb" type="rule"/>
@@ -1645,6 +1807,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="479b-2011-1673-9b12" name="Dwarf Ranger" hidden="false" collective="false" type="model">
@@ -1657,6 +1820,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1664,6 +1828,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8e77-d307-2416-a4bf" name="Dwarf Rangers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1681,6 +1846,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ae9d-7ca4-16a9-b011" name="Dwarf Ranger" hidden="false" collective="false" type="model">
@@ -1693,6 +1859,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1700,6 +1867,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1716,6 +1884,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="229a-d0b0-45cf-dd7d" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1732,6 +1901,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1754,6 +1924,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1761,9 +1932,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d21b-4748-3e74-0e99" name="Dwarf Crazed Psychotic Axe-wielding Maniacs [117 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="dec8-d0f8-7998-f28a" name="Crazed Psychotics" hidden="false" targetId="2b40-80c8-12cf-8f44" type="rule"/>
         <infoLink id="ed08-d328-683a-4395" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
@@ -1792,6 +1967,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29d1-a06a-4baf-d6c5" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1800,6 +1976,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1817,6 +1994,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="33.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="276b-6b61-b1b8-d49d" name="Maniac" hidden="false" collective="false" type="model">
@@ -1829,6 +2007,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1836,9 +2015,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5b61-10d0-464f-e4bf" name="Dwarf Stone Thrower [102 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="fca3-67c3-8e81-c0ba" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="913d-aef7-9d58-1ef1" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1860,6 +2043,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1ccb-6fac-9c0f-24bd" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -1868,6 +2052,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1884,6 +2069,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1891,9 +2077,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="caa8-a18a-d2a9-ee72" name="Dwarf Cannon [98 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="9769-b86a-4858-2c28" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="b19f-ad64-bf7b-6d7d" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1916,6 +2106,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4bf2-d3bd-d61b-f63d" name="Large Cannon" hidden="false" collective="false" type="upgrade">
@@ -1924,6 +2115,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="100.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1940,6 +2132,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1947,9 +2140,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="55f2-2eeb-c566-db0a" name="Dwarf Bombard [93 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="83f7-d5f6-88a3-d5f5" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="8fc5-dce6-1e09-7439" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1971,6 +2168,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="45.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1987,6 +2185,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1994,9 +2193,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6f26-e1ce-d8ff-b54c" name="Dwarf Fire Cannon [108 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="a027-e0e9-2744-51a4" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
       </infoLinks>
@@ -2016,6 +2219,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2034,6 +2238,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2041,9 +2246,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5310-7ff4-c260-fc1f" name="Dwarf Bolt Thrower [90 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="790b-d4a5-4d29-2e02" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="97ed-e67a-be81-02b3" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2065,6 +2274,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83ee-bd8c-e8c7-59c6" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2074,6 +2284,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2090,6 +2301,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2097,9 +2309,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a844-a11e-a600-98e7" name="Dwarf Flying Machine" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="389f-1c24-2058-bf2e" type="max"/>
       </constraints>
@@ -2119,6 +2335,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="94.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2135,6 +2352,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f930-f93d-c612-99b8" name="Bombs" hidden="false" collective="false" type="upgrade">
@@ -2143,6 +2361,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2160,9 +2379,11 @@
                 <infoLink id="561d-640d-a8bc-6230" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
                 <infoLink id="e952-ad5a-9de5-6311" name="Ramshackle Contraption" hidden="false" targetId="182e-9b37-17f3-5b45" type="rule"/>
                 <infoLink id="b908-abb7-21f2-c2ae" name="Flying Machine With Bombs" hidden="false" targetId="953a-ca2d-befd-cc62" type="profile"/>
+                <infoLink id="808e-3e97-b5ae-3c53" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2178,6 +2399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2185,9 +2407,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a75b-c3ef-93c9-ec24" name="Dwarf Steam Juggernaut [245 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="3.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="c588-6c81-ab4a-9f61" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
         <infoLink id="83c9-9029-2019-a319" name="Juggernaut" hidden="false" targetId="db5d-a96a-7bfb-66f3" type="rule"/>
@@ -2201,6 +2427,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ada-d6e1-0313-f678" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4e2-fe55-9c03-ed0b" type="max"/>
           </constraints>
+          <infoLinks>
+            <infoLink id="0bca-5ba0-3040-fe3d" name="MoD3" hidden="false" targetId="a8ca-ba71-db97-bc20" type="rule"/>
+          </infoLinks>
           <selectionEntries>
             <selectionEntry id="4e07-8cb6-0f17-5dc6" name="Juggernaut" hidden="false" collective="false" type="upgrade">
               <infoLinks>
@@ -2208,6 +2437,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="215.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2224,6 +2454,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2246,6 +2477,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e117-43d7-fd7d-34ea" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -2261,6 +2493,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2276,6 +2509,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2292,6 +2526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1eb2-2c27-84c0-87e3" name="Large Cannon" hidden="false" collective="false" type="upgrade">
@@ -2301,6 +2536,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ccf-e126-235d-2834" name="Fire Cannon" hidden="false" collective="false" type="upgrade">
@@ -2309,6 +2545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7afc-c651-8c20-1a63" name="Organ Gun" hidden="false" collective="false" type="upgrade">
@@ -2317,6 +2554,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2324,9 +2562,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d036-c54c-7e19-e1a9" name="Dwarf Organ Gun" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="169d-15b8-ae92-e1ec" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="d3f9-4f0e-d07b-497e" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2348,6 +2590,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2364,6 +2607,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2371,6 +2615,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Elves.cat
+++ b/Elves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="fe3c-0690-8599-2c5a" name="Elves" revision="1" battleScribeVersion="2.02" authorName="the3dwaragmer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="fe3c-0690-8599-2c5a" name="Elves" revision="2" battleScribeVersion="2.02" authorName="the3dwaragmer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="f9fe-8a78-d73c-6467" name="Elven Lord" hidden="false" collective="false" targetId="9a7d-1a27-895a-cd53" type="selectionEntry"/>
     <entryLink id="806f-cefb-1bbc-16ba" name="Mounted Elven Lord" hidden="false" collective="false" targetId="b9d6-982d-12a3-da4d" type="selectionEntry"/>
@@ -19,6 +19,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="9a7d-1a27-895a-cd53" name="Elven Lord [108 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="fe12-55e3-e0ff-330f" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="f3cc-6c74-5912-cf0b" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -36,6 +39,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5ce-bd0d-9ffb-876f" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -44,6 +48,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f92-2628-6609-c9aa" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -52,6 +57,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -67,6 +73,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -83,6 +90,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f8ae-b91f-590a-7c2b" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -91,6 +99,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -107,6 +116,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="111c-d14e-6a91-733f" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -115,6 +125,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -141,6 +152,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="74.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="7d39-e268-cac6-3d83" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -153,6 +165,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -160,6 +173,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8af0-6cac-e8d4-77e7" name="Elven Lord in Spangly Armour" hidden="false" collective="false" type="upgrade">
@@ -178,6 +192,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="89.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="35e1-bb12-c48e-988f" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -190,6 +205,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -197,6 +213,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -212,6 +229,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fdcd-6dbb-bce5-8672" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -220,6 +238,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eaa6-34e8-00f5-a551" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -228,6 +247,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="483c-9564-26b4-8a72" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -236,6 +256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="22ad-5cfb-c2cd-dd74" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -244,6 +265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="05a5-8d47-94e8-b6c5" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -252,6 +274,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5aa7-4f4b-d873-75c6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -260,6 +283,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -267,9 +291,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b9d6-982d-12a3-da4d" name="Mounted Elven Lord [128 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="ae31-dfa0-3fde-3b87" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -290,6 +318,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b597-0aed-39a6-8f28" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -298,6 +327,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="82b8-2a75-6f1f-05e3" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -313,6 +343,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -328,6 +359,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -354,6 +386,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="82.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a28d-36dc-d687-1b8f" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -366,6 +399,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -373,6 +407,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90c7-df4d-caca-17e5" name="Elven Lord in Spangly Armour" hidden="false" collective="false" type="upgrade">
@@ -391,6 +426,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="97.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="7df7-ebf0-5514-88a3" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -403,6 +439,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -410,6 +447,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -426,6 +464,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7653-0ad0-3578-b9ad" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -434,6 +473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -450,6 +490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eb9e-3d69-a6aa-f295" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -458,6 +499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -484,6 +526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -499,6 +542,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d98f-55d4-8de6-7890" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -507,6 +551,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cc22-3b2a-dabb-a51b" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -515,6 +560,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5598-126b-0127-c9c2" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -523,6 +569,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7055-2bf9-ef34-9f9c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -531,6 +578,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44e0-87db-a938-fa18" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -539,6 +587,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e74-2c59-ce90-66fd" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -547,6 +596,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -554,9 +604,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a7d7-31cb-d9da-ee08" name="Elven Hero [77 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e244-973a-aa3a-3a44" type="max"/>
       </constraints>
@@ -579,6 +633,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -595,6 +650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0208-d959-9570-377b" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -603,6 +659,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -619,6 +676,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="685c-4a2f-b93e-452c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -627,6 +685,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e0a9-88cd-8f1e-0f48" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -635,6 +694,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -651,6 +711,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cde6-39de-1497-420a" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -659,6 +720,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="045d-1f45-8468-6271" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -667,6 +729,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -683,6 +746,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="77.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="942a-a907-5881-6da2" name="Elven Hero in Spangly Armour" hidden="false" collective="false" type="model">
@@ -691,6 +755,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="92.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -706,6 +771,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="93c3-ada6-5c63-3293" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -714,6 +780,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="24d7-c222-2ee0-5b3e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -722,6 +789,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2412-7ac2-bc62-e733" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -730,6 +798,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="50fd-b515-6764-b3ad" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -738,6 +807,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8683-aa9b-882f-49d7" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -746,6 +816,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3028-8858-380c-e959" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -754,6 +825,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -761,9 +833,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5416-8391-045e-6c54" name="Mounted Elven Hero [87 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fb2-3f4d-1dd6-609b" type="max"/>
       </constraints>
@@ -787,6 +863,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -803,6 +880,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1fed-0de8-ece0-c5dc" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -811,6 +889,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -827,6 +906,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02e7-e496-5a99-fdb8" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -835,6 +915,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3bdc-677e-6e9e-2c2b" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -843,6 +924,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -859,6 +941,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f574-f339-258e-0fe4" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -867,6 +950,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f458-8145-ed13-bd25" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -875,6 +959,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -891,6 +976,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="87.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffef-d41b-c9bd-b9eb" name="Elven Hero in Spangly Armour" hidden="false" collective="false" type="model">
@@ -899,6 +985,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="102.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -915,6 +1002,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -930,6 +1018,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15c0-f02e-301f-32fa" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -938,6 +1027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ec8-75ab-f29f-701f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -946,6 +1036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f7e4-3d5f-0037-c3fb" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -954,6 +1045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="60c1-2a21-767b-98bd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -962,6 +1054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="85f7-506e-7238-7494" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -970,6 +1063,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b704-c98a-3d08-9a90" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -978,6 +1072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -985,9 +1080,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2852-dd57-1bd8-8981" name="Elven Mage [62 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5cfe-635b-7ac6-df25" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="2194-6a48-821c-a892" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
@@ -1006,6 +1105,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1019,16 +1119,19 @@
             <selectionEntry id="c840-fcf6-2779-732c" name="Magic Level 1" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="128e-b58a-49db-8d8c" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd3f-9eb6-53de-0d24" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1051,6 +1154,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1fe6-b9f2-3f8b-ff96" name="Apprentices in Light Armour" hidden="false" collective="false" type="model">
@@ -1062,6 +1166,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1069,6 +1174,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ab3-a080-aba5-cce5" name="Daemons" hidden="false" collective="false" type="upgrade">
@@ -1085,6 +1191,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1092,6 +1199,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1108,6 +1216,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9165-7289-0e76-9d89" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1116,6 +1225,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1131,6 +1241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1147,6 +1258,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d67-08e8-8987-2d32" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1155,6 +1267,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e160-d6b2-7dda-db7b" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1163,6 +1276,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89f8-f18f-7b8a-5fbc" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1171,6 +1285,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ea48-7be2-2b8b-cb42" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1179,6 +1294,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b45f-2990-e201-b123" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1187,6 +1303,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad30-e0af-5d6b-d325" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1195,6 +1312,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d03-783d-93e0-39ec" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1203,6 +1321,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5bef-245a-a81b-fc0c" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1211,6 +1330,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="35f9-c6dd-d666-10d2" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1219,6 +1339,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e6de-aa4d-6796-8ce4" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1227,6 +1348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="79ac-2480-7ea8-9011" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1235,6 +1357,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eca0-3d73-e3b3-fcee" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1243,6 +1366,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d604-be1b-c53e-cc0c" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1251,6 +1375,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1266,6 +1391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7959-1486-daa3-4b49" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1277,6 +1403,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5fdb-17e4-ddc3-cc50" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1288,6 +1415,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b3d-3780-d660-94e9" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1299,6 +1427,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c25d-1013-4a1d-f1b7" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1310,6 +1439,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="654f-6b95-a2c8-536a" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1321,6 +1451,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e930-48f2-73a8-e2af" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1332,6 +1463,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3ae-6c35-f605-08dd" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1343,6 +1475,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="455f-f936-d77d-64ba" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1354,6 +1487,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a49-0760-f980-7b25" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1365,6 +1499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1c6d-bdb8-3909-5d61" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1376,6 +1511,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="932b-eca5-18ee-8dc0" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1387,6 +1523,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3e1d-1433-1c0f-4eb4" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1398,6 +1535,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b8f7-9ab0-6f8a-cafa" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1409,6 +1547,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1424,6 +1563,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7895-db08-6665-d0ab" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1432,6 +1572,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="abc5-24c8-c0f9-ca21" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1440,6 +1581,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8ed6-d4b4-cccc-4081" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1448,6 +1590,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="affa-f390-4df4-969c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1456,6 +1599,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0421-f681-4d4d-16c2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1464,6 +1608,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ad8-f128-5f6d-7b01" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1472,6 +1617,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1479,9 +1625,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aa6f-d68a-6c78-68f8" name="Elven Guard [95 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="ec30-f907-96cd-64fe" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
@@ -1500,6 +1650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1516,6 +1667,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e99-be7e-b83a-aaf5" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1524,6 +1676,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1546,6 +1699,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1570,6 +1724,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3f5b-444c-f1e7-5875" name="Elven Guard" hidden="false" collective="false" type="model">
@@ -1582,6 +1737,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1589,6 +1745,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0cd4-ce20-a380-2188" name="Elven Guard in Spangly Armour [+4 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1605,6 +1762,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="268b-535b-9120-39f2" name="Elven Guard Leader" hidden="false" collective="false" type="model">
@@ -1617,6 +1775,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1624,6 +1783,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1631,9 +1791,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="badc-3155-f998-0995" name="Elven Warriors [95 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="0610-b28c-232c-fdbf" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1650,6 +1814,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="79c0-f546-f1d0-0963" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1658,6 +1823,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f16-46c1-7f8f-a78d" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1666,6 +1832,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1681,6 +1848,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1697,6 +1865,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="daca-77a5-1a28-7eb8" name="Elven Warriors" hidden="false" collective="false" type="model">
@@ -1709,6 +1878,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1716,9 +1886,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d269-784b-2037-0b91" name="Elven Archers [105 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2fc8-e344-7e1f-6e56" name="Longbow" hidden="false" targetId="d4c8-3ef2-18de-85c0" type="profile"/>
         <infoLink id="850e-39cc-2c51-d09f" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
@@ -1739,6 +1913,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1763,6 +1938,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="38f8-5e00-0fdb-910b" name="Elven Archers" hidden="false" collective="false" type="model">
@@ -1775,6 +1951,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1782,6 +1959,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9a4-ecc6-9246-0d6a" name="Elven Archers in Light Armour [+2 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1798,6 +1976,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0502-fdea-edd0-763e" name="Elven Archer Leader" hidden="false" collective="false" type="model">
@@ -1810,6 +1989,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1817,6 +1997,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1824,9 +2005,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5d83-e361-70c9-499c" name="Elven Rangers [141 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="7046-634b-20d8-5ebd" name="Woodsman" hidden="false" targetId="e1f3-7817-0e4e-5cb9" type="rule"/>
         <infoLink id="da64-a1cf-d3a1-adc8" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
@@ -1848,6 +2033,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1872,6 +2058,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="36.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5230-bf49-1dcd-5443" name="Elven Rangers" hidden="false" collective="false" type="model">
@@ -1884,6 +2071,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1891,6 +2079,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f8f-189e-a46d-d71d" name="Elven Rangers in Spangly Armour [+4 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1907,6 +2096,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2fb9-dd34-6e54-c95e" name="Elven Ranger Leader" hidden="false" collective="false" type="model">
@@ -1919,6 +2109,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="40.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1926,6 +2117,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1933,9 +2125,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="39cd-09b5-a58e-b4fa" name="Elven Cavalry [79 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="ffc9-c443-ae86-28bd" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
         <infoLink id="8457-a642-ed5a-18f2" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
@@ -1955,6 +2151,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1971,6 +2168,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c205-30ae-4952-6105" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1979,6 +2177,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d546-1d97-27c2-9f4d" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -1994,6 +2193,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2016,6 +2216,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2039,6 +2240,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2061,6 +2263,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="33.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a880-6a8b-3651-2a12" name="Elven Cavalry" hidden="false" collective="false" type="model">
@@ -2073,11 +2276,13 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="23.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6212-14ad-16ae-6763" name="Cavalry in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2092,6 +2297,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="25.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="422e-b0c5-2157-57d3" name="Elven Cavalry Leader" hidden="false" collective="false" type="model">
@@ -2104,11 +2310,13 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="35.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a933-0dce-4e3c-3edd" name="Cavalry in Spangly Armour" hidden="false" collective="false" type="upgrade">
@@ -2123,6 +2331,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="29.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cbf4-98eb-637b-9bc5" name="Elven Cavalry Leader" hidden="false" collective="false" type="model">
@@ -2135,11 +2344,13 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="39.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2147,9 +2358,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="52d3-bc0e-f380-0876" name="Elven Knights [104 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="e6ac-8a00-4ef4-20c1" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
         <infoLink id="9fd5-3c7c-26b2-c868" name="Haughty Disdain" hidden="false" targetId="6a8d-ef1b-6f78-e15c" type="rule"/>
@@ -2178,6 +2393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2195,6 +2411,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="48.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="804c-4773-facd-9fcc" name="Elven Knights" hidden="false" collective="false" type="model">
@@ -2207,6 +2424,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2214,9 +2432,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d3d2-c832-23e1-9cb7" name="Giant Eagle [143 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="8cbc-73e8-57c5-aea5" name="Rock dropped by Eagle" hidden="false" targetId="c44d-adb8-ec8a-3dd4" type="profile"/>
       </infoLinks>
@@ -2239,6 +2461,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="143.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2255,6 +2478,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2262,9 +2486,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d7a0-4612-9a6d-2215" name="Elven Chariot [116 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="4160-5acc-9299-adcf" name="Longbow" hidden="false" targetId="d4c8-3ef2-18de-85c0" type="profile"/>
       </infoLinks>
@@ -2284,6 +2512,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="98.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2300,6 +2529,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2317,6 +2547,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2333,6 +2564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3bbc-1eac-4b59-d875" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2341,6 +2573,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f286-0f44-3008-dfb4" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2349,6 +2582,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2364,6 +2598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2371,9 +2606,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="555c-7461-6e9a-8467" name="Elven Bolt Thrower [93 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="e441-50b4-417c-8922" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2393,6 +2632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2409,6 +2649,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c226-9114-8dbb-c8aa" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2418,6 +2659,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2425,9 +2667,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1f4e-7ddd-0923-cd17" name="Elven Stone Thrower [105 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="baf1-a29c-e2e1-46da" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2447,6 +2693,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2463,6 +2710,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1bf9-67e1-1641-80e4" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -2471,6 +2719,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2478,6 +2727,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Gnolls.cat
+++ b/Gnolls.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6f32-651f-4105-5375" name="Gnolls" revision="1" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwaragmer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6f32-651f-4105-5375" name="Gnolls" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwaragmer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="c253-a1f4-cc5a-aa3d" name="Gnoll Chieftain [110 pts]" hidden="false" collective="false" targetId="ceea-205a-5863-8f33" type="selectionEntry"/>
     <entryLink id="4be6-0544-f612-81bd" name="Gnoll Shaman [66 pts]" hidden="false" collective="false" targetId="98e7-400a-37ff-3d3e" type="selectionEntry"/>
@@ -14,6 +14,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="ceea-205a-5863-8f33" name="Gnoll Chieftain [112 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="bf1b-12ca-08b1-43f5" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="27b6-e12b-c05e-78c2" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -32,6 +35,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="78.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d88-393c-df81-60ee" name="Gnoll Guard" hidden="false" collective="false" type="model">
@@ -44,6 +48,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -60,6 +65,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="909a-c84a-8c9b-ff93" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -68,6 +74,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7188-f700-ba7d-9b95" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -76,6 +83,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="37bc-ac49-ae68-f04f" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -84,6 +92,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88f8-1f67-852f-893a" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -92,6 +101,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="94eb-ddc2-d8c6-cbef" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -100,6 +110,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9823-d87b-a4de-8886" name="Morning Stars" hidden="false" collective="false" type="upgrade">
@@ -108,6 +119,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -124,6 +136,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2a21-5c35-794f-7009" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -132,6 +145,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5183-13f1-799a-eac1" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -140,6 +154,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -156,6 +171,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e50-17d9-7f11-5bc1" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -164,6 +180,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -179,6 +196,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="abc5-4ad8-6735-2988" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -187,6 +205,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e42a-95d8-d875-5683" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -195,6 +214,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="520f-e9ce-25c5-f7ca" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -203,6 +223,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55d7-0c31-e693-ed74" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -211,6 +232,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db72-f5da-527b-f765" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -219,6 +241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83cb-0aa0-639a-4ca5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -227,6 +250,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -234,9 +258,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="98e7-400a-37ff-3d3e" name="Gnoll Shaman [66 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="2646-bfeb-96bd-705a" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
         <categoryLink id="9b57-d316-be08-f09d" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -254,6 +282,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88a3-c66a-d580-4dfd" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -262,6 +291,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cdc5-5f88-ce65-6b13" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -270,6 +300,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -286,6 +317,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebee-1d13-4f8d-851c" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -294,6 +326,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -317,6 +350,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -324,6 +358,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1cfb-4578-c6a7-5726" name="Animal Spirits" hidden="false" collective="false" type="upgrade">
@@ -339,6 +374,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -346,6 +382,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -363,6 +400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="66.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -379,6 +417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="902f-c5bd-d344-31ed" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -387,6 +426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -402,6 +442,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c1a9-63fe-d1ba-ed48" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -413,6 +454,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d01-e748-d7ff-457b" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -424,6 +466,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6051-bb02-40a2-5107" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -435,6 +478,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1cb8-14ce-536a-f757" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -446,6 +490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5910-dbc8-18dc-0da4" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -457,6 +502,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="09b7-f33f-21fa-d97d" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -468,6 +514,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="80da-bce8-6fbb-71cc" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -479,6 +526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d81-5cfb-e4d5-38da" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -490,6 +538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1ae9-d269-7fd1-2307" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -501,6 +550,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a280-d673-22d9-35d1" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -512,6 +562,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="46f4-32bc-72b0-24c8" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -523,6 +574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90c0-9072-6ac8-4d3c" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -534,6 +586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1aca-e801-89fb-88fb" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -545,6 +598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -561,6 +615,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58f9-0626-51bb-345e" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -569,6 +624,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="06c4-0a29-a563-b87b" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -577,6 +633,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1360-383e-2681-04ed" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -585,6 +642,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c42f-1a42-7281-0b84" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -593,6 +651,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fdc1-0f95-08b3-6173" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -601,6 +660,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7236-6e02-bc9d-dc2a" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -609,6 +669,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a32e-b23f-a3d0-38bc" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -617,6 +678,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3182-b341-91c9-7b1e" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -625,6 +687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="492c-2af5-42a0-43df" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -633,6 +696,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9420-ee2e-eb84-d43b" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -641,6 +705,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02f4-dcc9-0644-d994" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -649,6 +714,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e69e-ea4b-d376-62b2" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -657,6 +723,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4aab-9e9e-3ce2-926b" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -665,6 +732,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -680,6 +748,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9af-7629-68df-f517" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -688,6 +757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9bdd-efa3-f4c4-8d97" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -696,6 +766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="379f-93c1-ff65-4f4c" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -704,6 +775,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6fdf-abac-4dc1-f696" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -712,6 +784,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c138-04e4-7077-451b" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -720,6 +793,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95d8-1dbb-4339-0ca6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -728,6 +802,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -735,9 +810,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="808f-7316-9868-4ba3" name="Gnoll Champion [83 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9443-1d62-6a77-9955" name="New CategoryLink" hidden="false" targetId="warrior command unit" primary="true"/>
       </categoryLinks>
@@ -754,6 +833,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="946b-5665-067b-cc59" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -762,6 +842,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66e6-3339-3e70-af50" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -770,6 +851,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="691d-b4f8-dc43-8ebd" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -778,6 +860,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ef5a-c3ed-b2a2-4b12" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -786,6 +869,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d7f-422f-c1ef-d2fa" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -794,6 +878,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2da9-eaa5-4d3f-4e68" name="Morning Stars" hidden="false" collective="false" type="upgrade">
@@ -802,6 +887,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -818,6 +904,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e241-3f9a-9ee0-a464" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -826,6 +913,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ddb3-b5c3-a6ce-4d62" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -834,6 +922,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -850,6 +939,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="512a-4340-62cd-c9f6" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -858,6 +948,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -875,6 +966,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="83.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -890,6 +982,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b04f-63c1-c77e-99b5" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -898,6 +991,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e2d-084f-9f76-333c" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -906,6 +1000,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dda6-e8a6-263e-1a64" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -914,6 +1009,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2d69-0f2e-9b87-0cbd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -922,6 +1018,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="74d0-dcb4-4aa9-9946" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -930,6 +1027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2763-559e-c84d-92af" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -938,6 +1036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -945,9 +1044,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6738-54c4-3339-67af" name="Gnoll Warriors [77 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="8c87-2f5f-d3b2-5d1a" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
@@ -975,6 +1078,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8043-fef9-3226-bac8" name="Gnoll Warrior" hidden="false" collective="false" type="model">
@@ -987,6 +1091,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -994,6 +1099,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18af-0d2f-84fc-08b4" name="Gnoll Warriors in Light Armour [+2 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1010,6 +1116,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3fe2-6f8b-8a31-58e8" name="Gnoll Pack master" hidden="false" collective="false" type="model">
@@ -1022,6 +1129,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1029,6 +1137,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1045,6 +1154,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e402-bd7c-d214-dac4" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1053,6 +1163,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1060,9 +1171,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4970-7f8f-b173-60cf" name="Gnoll Guard [87 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="4acb-c343-9343-9fd1" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1087,6 +1202,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="76e2-979e-5e12-56fe" name="Gnoll Guard" hidden="false" collective="false" type="model">
@@ -1099,6 +1215,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1106,6 +1223,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b053-c308-a8f5-451a" name="Gnoll Guard in Light Armour [+2 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1122,6 +1240,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4cad-b484-6ecd-2d11" name="Gnoll Pack master" hidden="false" collective="false" type="model">
@@ -1134,6 +1253,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1141,6 +1261,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1157,6 +1278,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4747-ae97-54f5-3a5c" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1165,6 +1287,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9367-280a-f0a9-aea9" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1173,6 +1296,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51e3-155f-e08b-ead3" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1181,6 +1305,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f34-e0d1-71da-d756" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -1189,6 +1314,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee28-b3ca-57bd-67cd" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -1197,6 +1323,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29e7-8bb3-2d76-6ae1" name="Morning Stars" hidden="false" collective="false" type="upgrade">
@@ -1205,6 +1332,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51a7-935e-cbc2-872f" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1220,6 +1348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1227,9 +1356,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="eb98-a54f-3cfe-1329" name="Gnoll Archers [82 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="41af-00a0-f106-8f1a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1253,6 +1386,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91d7-e459-79b2-eda6" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1268,6 +1402,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bce1-3949-1e74-e111" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -1276,6 +1411,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1292,6 +1428,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2eb2-f842-c886-81ec" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -1307,6 +1444,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1323,6 +1461,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="26.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6bd6-13ff-71c8-5795" name="Gnoll Archer" hidden="false" collective="false" type="model">
@@ -1335,6 +1474,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1342,15 +1482,19 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2efe-475b-9097-0f86" name="Gnoll Scouts [92 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac55-996f-1043-c14f" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="8527-bca2-aa85-90e1" name="Stealthy" hidden="false" targetId="dcb2-de55-1fca-e0a8" type="rule"/>
-        <infoLink id="0b52-2bd1-a1ef-d905" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+        <infoLink id="0b52-2bd1-a1ef-d905" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="32fa-7089-bcf5-5720" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -1368,6 +1512,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa91-c694-f200-caf7" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1376,6 +1521,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1398,6 +1544,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1413,6 +1560,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1430,6 +1578,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bdeb-67b3-2105-4bd6" name="Gnoll Scouts" hidden="false" collective="false" type="model">
@@ -1442,6 +1591,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1449,12 +1599,16 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ca29-8d81-164c-ae92" name="Gnoll Trackers [104 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="3315-3013-c1cf-2f2a" name="Woodsman" hidden="false" targetId="e1f3-7817-0e4e-5cb9" type="rule"/>
-        <infoLink id="41ee-98c8-c61b-62c0" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+        <infoLink id="41ee-98c8-c61b-62c0" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
         <infoLink id="cd2c-8a3a-a961-7158" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
@@ -1475,6 +1629,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="19.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1494,6 +1649,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b2e-69c8-a5e4-ad90" name="Gnoll Tracker in Light Armour" hidden="false" collective="false" type="model">
@@ -1505,6 +1661,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1521,6 +1678,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="586b-8d39-193a-e3ea" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1529,6 +1687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b805-05a3-0fd1-f26f" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1537,6 +1696,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5259-ad59-4326-704e" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -1545,6 +1705,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="69df-296f-2c6f-0d40" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -1553,6 +1714,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2efc-1d5d-384b-a8b0" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -1561,6 +1723,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e408-9f77-4bdb-f5cd" name="Morning Star" hidden="false" collective="false" type="upgrade">
@@ -1569,6 +1732,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1576,9 +1740,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="43b2-a0f2-3dbd-dee6" name="Gnoll Chariot [100 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="ad20-1194-af32-8961" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
       </categoryLinks>
@@ -1595,6 +1763,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6d5-6214-25e2-7067" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1603,6 +1772,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a8d0-463b-c291-3395" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1611,6 +1781,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1633,6 +1804,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1127-1604-6894-47b4" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -1648,6 +1820,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1663,6 +1836,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1679,6 +1853,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1694,11 +1869,12 @@
                 <infoLink id="86b7-2dac-0f1f-9fbc" name="Gnoll Chariot with crew, pulled by two hyenas" hidden="false" targetId="00bd-e5d9-8f1b-ae6c" type="profile"/>
                 <infoLink id="dd88-f20b-71f5-2ebb" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                 <infoLink id="8313-5e66-7d93-40ab" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
-                <infoLink id="e59d-67ce-7302-f6b9" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                <infoLink id="e59d-67ce-7302-f6b9" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
                 <infoLink id="6bfc-0076-9d39-d731" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="90.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1721,6 +1897,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1728,9 +1905,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ef5a-8658-be88-159f" name="Gnoll Stone Thrower [96 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="e068-e6ce-1eaa-f2d2" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -1757,6 +1938,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1764,6 +1946,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="108a-641c-0f3d-922c" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1782,6 +1965,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1789,6 +1973,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1805,6 +1990,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78bf-7696-bbdd-7078" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -1813,6 +1999,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1836,6 +2023,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e3ed-b852-70b3-0d00" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1851,6 +2039,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15b9-e903-91b5-26d8" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -1859,6 +2048,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1866,6 +2056,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Goblins.cat
+++ b/Goblins.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a5f0-ec9e-8401-d5df" name="Goblins" revision="1" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a5f0-ec9e-8401-d5df" name="Goblins" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="7c72-b3c6-5f8f-2aee" name="Goblin Chieftain [59 pts]" hidden="false" collective="false" targetId="9b2e-c57f-ec1e-d70d" type="selectionEntry"/>
     <entryLink id="2ce4-b851-6bc0-7617" name="Goblin Chieftain in Wolf Chariot [151 pts]" hidden="false" collective="false" targetId="6dce-754d-7cff-650c" type="selectionEntry"/>
@@ -18,6 +18,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="9b2e-c57f-ec1e-d70d" name="Goblin Chieftain [59 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="684c-00f7-2c9e-845f" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
       </infoLinks>
@@ -38,6 +41,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89d1-0ce8-8631-6724" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -46,6 +50,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -62,6 +67,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6eef-8ef2-f81e-4fe2" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -70,6 +76,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -86,6 +93,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd12-7d02-fb2b-7c52" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -94,6 +102,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27e5-5cc3-1cc9-31ef" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -102,6 +111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="009d-9f31-6687-b5da" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -110,6 +120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="80d6-5260-94ae-9e57" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -118,6 +129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73bb-d5b8-ef1f-a893" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -126,6 +138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99a4-20c0-aa8f-68dd" name="Massive Maces" hidden="false" collective="false" type="upgrade">
@@ -134,6 +147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -158,6 +172,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="41.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="77a5-7c5e-7263-acba" name="Goblin Bodyguard in Light Armour" hidden="false" collective="false" type="model">
@@ -170,6 +185,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -177,6 +193,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="372d-60dc-ff13-7f91" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -193,6 +210,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="51.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="396e-a1a7-1262-db43" name="Goblin Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -202,6 +220,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -209,6 +228,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -224,6 +244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c553-2ca2-2337-3ca8" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -232,6 +253,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b642-2130-c3cc-905e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -240,6 +262,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c5c-9816-1d75-ea85" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -248,6 +271,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="77ff-d53d-723c-f2dc" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -256,6 +280,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="606d-bc15-404e-83a7" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -264,6 +289,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9a13-efd0-27c5-2587" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -272,6 +298,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -279,15 +306,19 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6dce-754d-7cff-650c" name="Goblin Chieftain in Wolf Chariot [151 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="f1c6-f1e1-48f2-f552" name="Goblin Chariot with Chieftain, pulled by 2 wolves" hidden="false" targetId="0d81-8af5-08c1-ceb5" type="profile"/>
         <infoLink id="b31b-f3de-8e84-b4e3" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="cc50-080c-0f4a-d777" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
         <infoLink id="bff5-f502-493a-a27f" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-        <infoLink id="5956-6a94-9538-454a" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+        <infoLink id="5956-6a94-9538-454a" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="25ce-5c59-3aa0-756d" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
@@ -305,6 +336,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -321,6 +353,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c571-82a5-3ee9-af1d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -329,6 +362,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd32-ccce-cccb-3604" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -337,6 +371,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf8b-6fe6-187e-9810" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -345,6 +380,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2590-1570-d5df-4eee" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -353,6 +389,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cc69-6e4e-9ca1-f750" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -361,6 +398,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1aae-fce8-afbc-ea9f" name="Massive Maces" hidden="false" collective="false" type="upgrade">
@@ -369,6 +407,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -391,6 +430,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -407,6 +447,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4738-e2f2-5397-28bf" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -415,6 +456,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -431,6 +473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a136-b4f1-1307-5df6" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -439,6 +482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -455,6 +499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -479,6 +524,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="146.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -486,6 +532,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8697-6dc8-aec9-1d96" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -502,6 +549,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="156.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -509,6 +557,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -525,6 +574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a0f-ba25-9f29-f0be" name="Dire Wolves" hidden="false" collective="false" type="upgrade">
@@ -533,6 +583,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -548,6 +599,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e3af-972c-2171-16b8" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -556,6 +608,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="beed-9166-0423-47c6" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -564,6 +617,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98a8-c5c7-8738-bd04" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -572,6 +626,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5a3f-c39b-2359-5891" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -580,6 +635,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="801e-7660-3546-a998" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -588,6 +644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a98c-e1ae-a737-32ec" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -596,6 +653,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -603,9 +661,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9b6c-6957-d526-e7ea" name="Goblin Shaman [52 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a01d-10ea-25e9-6527" type="max"/>
       </constraints>
@@ -626,6 +688,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3df4-abda-254d-2942" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -634,6 +697,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3ce-9aea-4213-57ac" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -642,6 +706,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -658,6 +723,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c74-7420-d7e4-f4a2" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -666,6 +732,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -683,6 +750,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="52.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -706,6 +774,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="7.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -713,6 +782,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0e10-a7e6-7a05-cb74" name="Gobble Dogs" hidden="false" collective="false" type="upgrade">
@@ -729,6 +799,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="16.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -736,6 +807,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -754,6 +826,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="38cb-1368-ca79-cfdd" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -762,6 +835,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3624-d046-4359-4043" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -770,6 +844,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="01a2-3df1-fa23-0413" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -778,6 +853,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df7a-cf5c-7231-ce22" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -786,6 +862,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89e2-0470-6909-08d0" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -794,6 +871,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c07-4aab-ba23-7968" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -802,6 +880,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="11a7-47fe-1457-59a8" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -810,6 +889,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29a0-3721-3779-68c6" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -818,6 +898,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4dcb-dbe7-fedf-8690" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -826,6 +907,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1edb-1d69-93d6-647f" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -834,6 +916,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a745-8305-c14b-b9d6" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -842,6 +925,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2446-a881-881c-312d" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -850,6 +934,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="488c-3cd7-c1ed-f6f5" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -858,6 +943,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -873,6 +959,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e5e6-d09b-0d41-568d" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -884,6 +971,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="473f-be7a-4f8f-1d55" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -895,6 +983,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff38-a0be-5362-7824" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -906,6 +995,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="16d9-d23e-a8fc-7d05" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -917,6 +1007,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d56-ffa2-5697-4977" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -928,6 +1019,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6943-4d3c-7930-8237" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -939,6 +1031,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="05ac-455d-4ffe-b766" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -950,6 +1043,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce9d-0ab7-473a-237b" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -961,6 +1055,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="efdb-bbbc-a461-6785" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -972,6 +1067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7895-145a-9f45-63f4" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -983,6 +1079,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e0a-b41e-e84c-e4e8" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -994,6 +1091,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c76b-447a-d992-73e1" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1005,6 +1103,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4552-4f8a-1e41-813f" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1016,6 +1115,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1031,6 +1131,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebaf-d6b4-1cd7-95de" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1039,6 +1140,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0592-ad61-3898-306a" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1047,6 +1149,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="47e7-024e-09b0-a96c" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1055,6 +1158,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ea52-795c-4c00-73ca" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1063,6 +1167,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b32-0a76-349b-7a45" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1071,6 +1176,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4575-0bb4-df35-676b" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1079,6 +1185,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1086,9 +1193,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="edf4-0805-90d6-cb5d" name="Goblin Guard [49 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c981-9d20-788f-5870" type="max"/>
       </constraints>
@@ -1111,6 +1222,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="286a-ea49-46c1-7f63" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1119,6 +1231,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bca3-60fb-ac29-f47e" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -1127,6 +1240,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83f9-6596-57c9-086e" name="Maces" hidden="false" collective="false" type="upgrade">
@@ -1135,6 +1249,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebcb-6b88-a645-dd7d" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1150,6 +1265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1174,6 +1290,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="89ea-e8d9-ce94-e742" name="Goblin Guard in Light Armour" hidden="false" collective="false" type="model">
@@ -1186,6 +1303,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1193,6 +1311,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e3e4-db71-b73d-7e2b" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1209,6 +1328,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b966-b009-58c1-6eaa" name="Goblin Guard in Medium Armour" hidden="false" collective="false" type="model">
@@ -1221,6 +1341,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1228,6 +1349,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1235,9 +1357,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="58a6-33e4-8a2f-c503" name="Goblin Warriors [47 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="cc8b-e368-dfd6-818e" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
@@ -1257,6 +1383,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="19.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9da7-eb54-800b-5442" name="Goblin Warriors" hidden="false" collective="false" type="model">
@@ -1269,6 +1396,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="7.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1285,6 +1413,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c194-43f5-df69-277a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1293,6 +1422,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a5bd-fe5b-3b19-2481" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1301,6 +1431,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1308,9 +1439,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c835-bc33-0ef5-7675" name="Goblin Archers [47 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="49e4-0c80-f821-ec0e" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="46d4-aa05-c21a-208d" name="Bow" hidden="false" targetId="95e1-d9f2-8182-5835" type="profile"/>
@@ -1340,6 +1475,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2b83-ca48-70fb-7d88" name="Goblin Archers with Bow and Sword or Axe" hidden="false" collective="false" type="model">
@@ -1352,6 +1488,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1359,6 +1496,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0d74-f50e-b097-464a" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1375,6 +1513,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8475-3024-5ba0-6198" name="Goblin Archers in Light Armour with Bow and Sword or Axe" hidden="false" collective="false" type="model">
@@ -1387,6 +1526,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1394,6 +1534,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1401,9 +1542,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="af02-f99a-22b1-78fc" name="Whirling Dervishes [90 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5258-48cf-2412-63d5" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1421,6 +1566,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1428,9 +1574,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d07b-876f-bc12-954b" name="Goblin Wolf Riders [69 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="01d5-4467-aab1-1f84" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
@@ -1450,6 +1600,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1474,6 +1625,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3d06-ffd9-7243-e241" name="Goblin Wolf Riders" hidden="false" collective="false" type="model">
@@ -1486,6 +1638,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1493,6 +1646,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf8b-3e1d-9e60-36a6" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1509,6 +1663,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="33.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0baf-20b4-d706-5d51" name="Goblin Wolf Riders in Light Armour" hidden="false" collective="false" type="model">
@@ -1521,6 +1676,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1528,6 +1684,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1550,6 +1707,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1566,6 +1724,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa72-260f-56ae-dfb4" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1574,6 +1733,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="977b-2093-e683-2cee" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1582,6 +1742,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1589,14 +1750,18 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="607c-0a91-69c5-0af3" name="Goblin Wolf Chariot [99 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="9f5c-9175-15e7-f2ef" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="57e8-c5d6-eec0-844c" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
         <infoLink id="8b4e-eb2a-1610-d64c" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-        <infoLink id="7464-2b60-0154-2082" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+        <infoLink id="7464-2b60-0154-2082" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ceb1-a0bd-6ee2-5d5f" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
@@ -1613,6 +1778,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1629,6 +1795,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="defe-df41-ead1-171e" name="Dire Wolves" hidden="false" collective="false" type="upgrade">
@@ -1637,6 +1804,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1659,6 +1827,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1675,6 +1844,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8f70-262a-31ab-09e0" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1683,6 +1853,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e08c-a28d-b25e-63ff" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1691,6 +1862,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1707,6 +1879,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1723,6 +1896,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="89.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1730,9 +1904,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6116-5bf2-30da-f941" name="Goblin Sprog Swarm [81 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="973d-e14a-ab21-28ee" name="New CategoryLink" hidden="false" targetId="c820-d327-811d-1144" primary="true"/>
       </categoryLinks>
@@ -1750,6 +1928,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1772,6 +1951,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1779,9 +1959,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cb00-866a-fe1c-a04c" name="Gobble Dog Pack [83 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="0aa4-14ad-ef36-eed2" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="bfe1-3535-f4b2-4beb" name="Frenzied Charge" hidden="false" targetId="1c49-276e-425d-0999" type="rule"/>
@@ -1803,6 +1987,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1822,6 +2007,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="19.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f52d-6826-667d-6e22" name="Pack Master in Medium Armour" hidden="false" collective="false" type="model">
@@ -1833,6 +2019,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1849,6 +2036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a7e7-98a3-b32a-fae0" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1857,6 +2045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3205-56ff-059e-6088" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1865,6 +2054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1872,9 +2062,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e95e-cc72-7367-c272" name="Trolls [105 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="c519-02a4-fd04-1f53" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="c042-94cb-bb35-1f8e" name="Regenerate" hidden="false" targetId="0a0c-ed4c-9647-4398" type="rule"/>
@@ -1896,6 +2090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1903,9 +2098,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d779-99c9-c589-31fc" name="Goblin Stone Thrower [63 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="a4dc-af09-4456-606c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="3eca-9fbb-655e-f5d6" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1926,6 +2125,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b064-2191-2cb2-5d33" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -1934,6 +2134,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1958,6 +2159,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="3.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1965,6 +2167,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87b7-d89c-b55e-5c9b" name="Goblin Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1981,6 +2184,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1988,6 +2192,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2004,6 +2209,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af7f-d914-8f2d-524a" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2019,6 +2225,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="578b-b6a5-e352-748d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2034,6 +2241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2041,9 +2249,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9096-65fd-09c1-25cc" name="Goblin Bolt Thrower [51 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2587-b159-79a8-b8fb" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="a66f-4aea-0bb9-3d30" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2072,6 +2284,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="3.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2079,6 +2292,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10c8-9568-04ba-1d07" name="Goblin Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2095,6 +2309,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2102,6 +2317,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2118,6 +2334,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="31db-0295-7487-293d" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2127,6 +2344,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2143,6 +2361,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="823a-5d06-2b30-16f8" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2158,6 +2377,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0007-03c6-6849-4199" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2173,6 +2393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2180,6 +2401,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Halflings.cat
+++ b/Halflings.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="745c-5adf-6444-cac7" name="Halflings" revision="1" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="745c-5adf-6444-cac7" name="Halflings" revision="2" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d891-2083-8b78-b275" name="Halfling Chief Cheriff [85 pts]" hidden="false" collective="false" targetId="c9ff-893e-2ec9-3544" type="selectionEntry"/>
     <entryLink id="748f-2466-4dcf-674f" name="Halfling Chief Sheriff in Cart [130 pts]" hidden="false" collective="false" targetId="6a05-8937-f0c2-efaa" type="selectionEntry"/>
@@ -16,6 +16,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="c9ff-893e-2ec9-3544" name="Halfling Chief Sheriff [85 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="1a7f-ec79-5436-2ba0" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="dd40-1170-66ad-3992" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -45,6 +48,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="69.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="66e8-ed3b-530e-0911" name="Henchmen" hidden="false" collective="false" type="model">
@@ -57,6 +61,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -64,6 +69,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c11-8bf4-3580-e403" name="Light Armour (10pts + 2pts per Henchmen)" hidden="false" collective="false" type="upgrade">
@@ -80,6 +86,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="79.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="7adf-df3c-4c6d-b8b4" name="Henchmen" hidden="false" collective="false" type="model">
@@ -92,6 +99,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -99,6 +107,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -115,6 +124,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1095-ef0c-84fa-c09d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -123,6 +133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="13d7-55cd-a401-ee1d" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -131,6 +142,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -146,6 +158,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -168,6 +181,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2350-2378-061f-0248" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -183,6 +197,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -205,6 +220,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -221,6 +237,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7385-dfc0-975d-c7f0" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -229,6 +246,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -245,6 +263,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8e5c-b2b2-fe84-aec4" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -253,6 +272,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -268,6 +288,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="03f7-9a1e-3658-77d1" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -276,6 +297,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7279-b221-bae1-afda" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -284,6 +306,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7c2b-b70c-dc06-1911" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -292,6 +315,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bbe-8769-e446-3925" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -300,6 +324,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a973-4a7c-756a-11b8" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -308,6 +333,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e3c-9fd8-e44e-3485" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -316,6 +342,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -323,9 +350,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6a05-8937-f0c2-efaa" name="Halfling Chief Sheriff in Cart [130 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="54b0-1542-a426-c212" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="f643-fe7d-7715-b283" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -348,6 +379,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0d87-0c59-7871-784a" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -356,6 +388,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -372,6 +405,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b6bc-3982-cbe6-426a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -380,6 +414,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -396,6 +431,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed7e-3922-a815-9f0e" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -404,6 +440,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f5c7-7f85-db23-2118" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -412,6 +449,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -427,6 +465,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -449,6 +488,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -461,6 +501,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -480,6 +521,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -496,6 +538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -512,6 +555,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="130.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9eac-ba4f-c7b9-bd6d" name="Halfling Chief Sheriff in Light Armour (on Foot)" hidden="false" collective="false" type="model">
@@ -520,6 +564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="140.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -535,6 +580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d29b-0232-16d2-edf2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -543,6 +589,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b2b0-799a-e3fa-0669" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -551,6 +598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e9ff-cae1-c686-6e1a" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -559,6 +607,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="063a-988e-aa82-6815" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -567,6 +616,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c60a-3804-e4d0-d447" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -575,6 +625,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ab2-e0c3-669c-4672" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -583,6 +634,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -590,9 +642,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a39d-0ad7-0df8-8f0f" name="Halfling Fortune Teller [51 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b46-a320-d4c8-6ce1" type="max"/>
       </constraints>
@@ -613,6 +669,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="855d-c917-3b73-2f38" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -621,6 +678,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="623e-9e06-264e-c979" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -629,6 +687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -645,6 +704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0ab-063d-6822-a803" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -653,6 +713,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -675,6 +736,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -692,6 +754,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="45.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -715,6 +778,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -722,6 +786,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f95-376f-1f4a-b62a" name="Spirit Guides" hidden="false" collective="false" type="upgrade">
@@ -738,6 +803,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -745,6 +811,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -760,6 +827,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8694-de67-033e-6e89" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -771,6 +839,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffd6-088f-3860-a2a7" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -782,6 +851,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f81-a6e7-f754-4f5b" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -793,6 +863,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e909-9414-093a-938d" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -804,6 +875,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd56-9008-3bf1-7e25" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -815,6 +887,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78fe-0325-3cd6-0df7" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -826,6 +899,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f942-2fde-bd85-c35b" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -837,6 +911,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="42ba-bf6d-ae9c-c0a0" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -848,6 +923,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a922-cd29-1ab1-fde2" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -859,6 +935,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="85d9-7edb-2684-f909" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -870,6 +947,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a90a-507f-1346-c7de" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -881,6 +959,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e20d-b40e-00ab-de80" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -892,6 +971,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc99-b403-0ef3-ec6c" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -903,6 +983,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -919,6 +1000,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98f5-7e62-7e5a-a589" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -927,6 +1009,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18a5-27ab-cbb8-9e02" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -935,6 +1018,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36a4-b006-6e1a-47b7" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -943,6 +1027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44a8-6cdb-a591-c5a7" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -951,6 +1036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="82e8-b315-c4ce-5ab1" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -959,6 +1045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c384-dadd-fadd-4c51" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -967,6 +1054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="57e2-6056-2442-9e07" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -975,6 +1063,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e8fa-1465-1ab9-b874" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -983,6 +1072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="47c0-e7c7-e115-9899" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -991,6 +1081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f711-1a08-7701-94bc" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -999,6 +1090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2cf2-7d1b-16b0-1de2" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1007,6 +1099,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4cec-0dae-1caf-25e7" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1015,6 +1108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="69df-5769-e05f-fb98" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1023,6 +1117,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1038,6 +1133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e1b9-4f9f-fa7b-dd8a" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1046,6 +1142,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bfd7-d0c1-6fad-b2bd" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1054,6 +1151,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6856-4bcc-a81a-a70e" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1062,6 +1160,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d989-27f2-c683-fcbc" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1070,6 +1169,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="54de-cad1-f3b2-6170" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1078,6 +1178,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cafb-d6ac-dae8-6660" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1086,6 +1187,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1093,9 +1195,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8dcb-a098-4ac4-094e" name="Halfling Clan Chief [76 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="3073-8db1-90d1-3678" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
       </infoLinks>
@@ -1116,6 +1222,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="76.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6307-bc33-7de0-0d94" name="Clan Chief in Light Armour" hidden="false" collective="false" type="model">
@@ -1124,6 +1231,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1139,6 +1247,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1155,6 +1264,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="740f-0f75-2fca-c47f" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1163,6 +1273,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1179,6 +1290,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18ea-60fa-6daf-c9dd" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1187,6 +1299,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62a7-2b63-ffb1-a6df" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1195,6 +1308,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1210,6 +1324,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1225,6 +1340,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1241,6 +1357,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27db-415b-be75-94aa" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1249,6 +1366,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bba2-bdd3-8a1f-d0ec" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1257,6 +1375,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1272,6 +1391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a581-fcb2-8d9b-23cc" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1280,6 +1400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c113-b6c0-51bf-836e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1288,6 +1409,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="64e2-8887-ab37-3d45" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1296,6 +1418,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a675-8ee6-eb19-925e" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1304,6 +1427,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="377a-fa27-043d-1f1a" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1312,6 +1436,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fa66-177b-9ee6-9387" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1320,6 +1445,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1327,9 +1453,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3eed-5ce8-9c18-f10c" name="Mounted Halfling Clan Chief [87 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="ebc6-cb05-9577-16d7" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
         <infoLink id="54bb-2468-e7df-a5d0" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
@@ -1351,6 +1481,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="87.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f12-ab2c-9701-24cc" name="Clan Chief in Light Armour" hidden="false" collective="false" type="model">
@@ -1359,6 +1490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="97.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1374,6 +1506,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1390,6 +1523,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e42c-a8d2-a6c6-e4fc" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1398,6 +1532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1414,6 +1549,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df88-9573-39dc-8d71" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1422,6 +1558,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30e1-e3d1-63c1-8325" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1430,6 +1567,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1445,6 +1583,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1461,6 +1600,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="963e-e2cb-dd16-a2be" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1469,6 +1609,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44a3-6d7b-f763-cbb8" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1477,6 +1618,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1492,6 +1634,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1507,6 +1650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="68f9-fe1e-70bd-534f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1515,6 +1659,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a2a1-3513-f2c9-a58a" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1523,6 +1668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6716-3cf0-73c6-27b5" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1531,6 +1677,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a91-50cf-1dd2-831d" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1539,6 +1686,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ab1a-b3b3-b4d3-e21c" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1547,6 +1695,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88a6-fdec-8403-c698" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1555,6 +1704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1562,11 +1712,15 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="19e0-8c7c-366c-d7d0" name="Halfling Sheriffs [47 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
-        <infoLink id="58b0-8f0e-5974-caef" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="58b0-8f0e-5974-caef" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ad7c-763f-905f-fbf6" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -1591,6 +1745,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95d3-8149-6187-d6cd" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1606,6 +1761,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5cb-3200-ac5c-1d1c" name="Staves" hidden="false" collective="false" type="upgrade">
@@ -1614,6 +1770,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1636,6 +1793,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6bcb-e409-ee0a-e017" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -1651,6 +1809,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1666,6 +1825,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1690,6 +1850,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="364e-cc5f-1aea-94e5" name="Halfling Sheriffs" hidden="false" collective="false" type="model">
@@ -1702,6 +1863,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1709,6 +1871,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f11c-4a92-d889-7459" name="Sheriffs in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1725,6 +1888,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="95e1-8e9b-f11d-2a5a" name="Halfling Sheriffs" hidden="false" collective="false" type="model">
@@ -1737,6 +1901,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1744,6 +1909,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1766,6 +1932,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1773,9 +1940,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0545-0a42-e1f7-1b28" name="Halfling Militia [42 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3e7b-2996-2b0a-b4be" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1793,6 +1964,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7fd4-635d-49df-f7b3" name="Halfling Militia" hidden="false" collective="false" type="model">
@@ -1805,6 +1977,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="6.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1820,6 +1993,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1842,6 +2016,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1857,6 +2032,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1880,6 +2056,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d12-d5be-81f0-dfce" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1895,6 +2072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a07f-6229-8a1b-41d6" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1910,6 +2088,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="361a-0092-7d5d-acbb" name="Club" hidden="false" collective="false" type="upgrade">
@@ -1918,6 +2097,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6415-c6fc-feb6-0717" name="Cudgel" hidden="false" collective="false" type="upgrade">
@@ -1926,6 +2106,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af91-65c7-6253-67b5" name="Staves" hidden="false" collective="false" type="upgrade">
@@ -1941,6 +2122,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1948,9 +2130,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ad9d-9e1b-c214-43c1" name="Halfling Archers [52 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b163-839c-21e9-2497" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1967,6 +2153,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8c21-9f4e-34bf-5f04" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -1982,6 +2169,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1999,6 +2187,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fcbb-51f2-f96c-c4da" name="Archer" hidden="false" collective="false" type="model">
@@ -2011,6 +2200,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2034,6 +2224,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1335-03d3-3c17-41f9" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2049,6 +2240,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="97e3-1af0-2de6-3c95" name="Club" hidden="false" collective="false" type="upgrade">
@@ -2057,6 +2249,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ad48-1bc6-547c-af95" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -2072,6 +2265,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -2089,6 +2283,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2111,6 +2306,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2118,9 +2314,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="00b9-460a-80f2-affb" name="Halfling Urchin Swarm [141 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5702-500b-e79d-d4d7" name="New CategoryLink" hidden="false" targetId="c820-d327-811d-1144" primary="true"/>
       </categoryLinks>
@@ -2137,6 +2337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="47.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2152,6 +2353,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2174,6 +2376,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2196,6 +2399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2203,12 +2407,16 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="24b7-8d95-bb2a-1795" name="Mounted Halflings [63 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="36c1-a5f8-fe10-ae8b" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-        <infoLink id="62ee-792f-bc27-4ee9" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="62ee-792f-bc27-4ee9" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1971-4957-7a2d-ce24" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
@@ -2234,6 +2442,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="93a1-252a-d1db-d1ee" name="Mounted Halfling" hidden="false" collective="false" type="model">
@@ -2246,6 +2455,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2253,6 +2463,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="54d6-172a-2723-352e" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2269,6 +2480,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5ef4-2e25-c462-83e9" name="Mounted Halfling" hidden="false" collective="false" type="model">
@@ -2281,6 +2493,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2288,6 +2501,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2303,6 +2517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2319,6 +2534,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4031-752e-741a-5060" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2327,6 +2543,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8f83-9b07-33a2-3550" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2335,6 +2552,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2357,6 +2575,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2364,9 +2583,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="87d2-b341-dc57-0825" name="Halfling Stone Thrower [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="344e-8498-6d57-e0cb" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2385,6 +2608,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="6.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2401,6 +2625,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2424,6 +2649,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5de3-ff28-8c06-7e79" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2439,6 +2665,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4985-ebaa-f7e1-ce89" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -2447,6 +2674,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2454,9 +2682,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bac5-4a06-ae31-2485" name="Halfling Bolt Thrower [60 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5ad0-37c1-0960-3fca" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2475,6 +2707,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="6.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2491,6 +2724,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2514,6 +2748,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0822-daf3-42c9-e209" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2529,6 +2764,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e261-5f7e-70f0-43b7" name="Clubs" hidden="false" collective="false" type="upgrade">
@@ -2537,6 +2773,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2552,6 +2789,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2559,6 +2797,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Knights working copy v1.cat
+++ b/Knights working copy v1.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2855-3dab-f953-6528" name="Knights" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2855-3dab-f953-6528" name="Knights" revision="3" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d945-4af9-b188-d23e" name="Court Wizard" hidden="false" collective="false" targetId="4e36-8ca9-21c5-f370" type="selectionEntry"/>
     <entryLink id="a117-4d48-a7c7-ed6c" name="Foot Knights" hidden="false" collective="false" targetId="2296-e410-da07-d236" type="selectionEntry"/>
@@ -37,6 +37,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4e36-8ca9-21c5-f370" name="Court Wizard (56 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="326e-0e5e-49ee-cb8c" type="max"/>
       </constraints>
@@ -62,6 +65,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="55.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -78,6 +82,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f6c-e715-66f1-7d0c" name="Tough Lvl 2" hidden="false" collective="false" type="upgrade">
@@ -86,6 +91,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -102,6 +108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -129,6 +136,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3208-10c7-f7db-ecc0" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -137,6 +145,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="08db-1b7a-ac6c-3e95" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -145,6 +154,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -167,6 +177,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -174,6 +185,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f0e-2c55-63ab-5296" name="Wizards Familiars" hidden="false" collective="false" type="upgrade">
@@ -190,6 +202,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -197,6 +210,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -213,6 +227,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="440d-72f7-f47d-9715" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -221,6 +236,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d9c-a064-187b-5c99" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -229,6 +245,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad45-daa5-dd02-ddec" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -237,6 +254,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d6f2-3852-2a24-4a1c" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -245,6 +263,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87f7-1236-a1a3-ea1e" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -253,6 +272,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ce9-bc0a-a30a-1c8b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -261,6 +281,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c07c-9d16-21e5-0feb" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -269,6 +290,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a7de-f6a3-5498-6a3b" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -277,6 +299,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6630-5ea8-bf55-4b5c" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -285,6 +308,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ecf9-32b3-d437-cce3" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -293,6 +317,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff03-207d-b5fa-5595" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -301,6 +326,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1dea-a210-287f-2705" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -309,6 +335,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8580-b297-4f17-698e" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -317,6 +344,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -332,6 +360,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5ac-60df-2376-b997" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -343,6 +372,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bff-e72b-9032-3e03" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -354,6 +384,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ce1-b9ca-4e65-b6ac" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -365,6 +396,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e33-b72a-d19e-bc45" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -376,6 +408,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bd5-8da3-0c1a-c789" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -387,6 +420,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5e18-79d3-01dd-f1d3" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -398,6 +432,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="538c-ac74-2847-0992" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -409,6 +444,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="620c-21b8-9463-3cb2" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -420,6 +456,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5f38-2b66-4069-0456" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -431,6 +468,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04e0-0e54-7f46-4e78" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -442,6 +480,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="81fc-daf9-0b1b-1b51" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -453,6 +492,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed3c-182f-f9fd-e59a" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -464,6 +504,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da40-ee64-4a81-3605" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -475,6 +516,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -490,6 +532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="caa3-78c5-5995-ba58" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -498,6 +541,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5dbb-b1fe-a8ed-bb90" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -506,6 +550,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99e9-0302-37ed-754d" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -514,6 +559,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5588-ad6d-2a56-3afc" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -522,6 +568,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e814-80c1-10c6-00e7" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -530,6 +577,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e313-6747-96ce-f6fa" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -538,6 +586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -545,9 +594,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2296-e410-da07-d236" name="Foot Knights (77pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2da5-f815-5f05-5d85" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
       </infoLinks>
@@ -568,6 +621,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7945-8dc5-2f0e-02e0" name="Foot Knights" hidden="false" collective="false" type="model">
@@ -580,6 +634,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="13.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -596,6 +651,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83b5-2567-73cc-3512" name="Mace" hidden="false" collective="false" type="upgrade">
@@ -604,6 +660,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="70fa-100a-9ab9-f3e5" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -612,6 +669,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e71b-68a6-a5e9-1ac9" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -620,13 +678,14 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="43aa-170b-4c5e-43a3" name="Unit Upgrades" hidden="false" collective="false">
           <entryLinks>
-            <entryLink id="9d2b-1da9-b816-cd18" name="Zealous" hidden="false" collective="false" targetId="23bc-d28a-656c-3fd5" type="selectionEntry">
+            <entryLink id="9d2b-1da9-b816-cd18" name="Foot Knights (77pts base)" hidden="false" collective="false" targetId="2296-e410-da07-d236" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
@@ -643,17 +702,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="23bc-d28a-656c-3fd5" name="Zealous" hidden="false" collective="false" type="upgrade">
-      <infoLinks>
-        <infoLink id="00f3-1145-8dd3-402e" name="Zealous" hidden="false" targetId="45bb-28cf-94fd-f899" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f2d3-51c1-7590-f825" name="Foot Retainers (72pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3bfe-a540-57d2-f394" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -679,6 +734,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b637-3ab2-6835-69c0" name="Foot Retainer" hidden="false" collective="false" type="model">
@@ -691,6 +747,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -698,6 +755,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c57c-1e1b-9b14-f4c5" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -714,6 +772,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c664-0e0a-1dba-763b" name="Foot Retainer Sergeant" hidden="false" collective="false" type="model">
@@ -727,6 +786,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -734,6 +794,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -750,6 +811,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="94f1-d8e2-ff21-47de" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -758,6 +820,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="423c-9030-53f6-a19b" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -766,6 +829,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -785,9 +849,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e0e0-025c-09d2-4e02" name="Archers (67pts base)" hidden="false" collective="false" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="4974-1a8f-32ef-03a6" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -813,6 +881,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1ae1-6a75-6bed-c849" name="Archer" hidden="false" collective="false" type="model">
@@ -825,6 +894,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -832,6 +902,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f718-282b-4899-2bb7" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -849,6 +920,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="40c9-ade9-0f20-5673" name="Archer" hidden="false" collective="false" type="model">
@@ -861,6 +933,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -868,6 +941,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -891,6 +965,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0fb2-1984-62a7-e547" name="Bow" hidden="false" collective="false" type="upgrade">
@@ -899,6 +974,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -922,6 +998,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4297-115f-1e92-90bd" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -930,6 +1007,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -945,6 +1023,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -952,9 +1031,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8d42-0633-18ea-46a3" name="Crossbowmen (72 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3367-091b-c4ec-8f3d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -969,6 +1052,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -985,6 +1069,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78c7-6f21-1de7-1c4d" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -1000,6 +1085,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1025,6 +1111,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="af26-600e-bb96-14bd" name="Crossbowman Seargeant" hidden="false" collective="false" type="model">
@@ -1038,6 +1125,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1045,6 +1133,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f907-e902-d680-eef5" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1062,6 +1151,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ba87-8a1d-0f2b-0e9d" name="Crossbowman Seargeant" hidden="false" collective="false" type="model">
@@ -1075,6 +1165,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1082,6 +1173,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="976e-0393-e70a-e7eb" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1099,6 +1191,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f44d-41cd-861a-ca35" name="Crossbowman Seargeant" hidden="false" collective="false" type="model">
@@ -1112,6 +1205,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1119,6 +1213,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1126,9 +1221,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8405-fc2d-45e0-0c26" name="Arbalestiers (Hvy Xbow) (72 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="dc61-2813-ce77-d4a9" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
         <infoLink id="c63e-ae16-0b08-59f1" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
@@ -1147,6 +1246,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1163,6 +1263,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d23b-f47c-042c-60af" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -1178,6 +1279,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1202,6 +1304,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c0c9-e5ae-da5c-56ca" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1214,6 +1317,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1221,6 +1325,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c1be-d060-b37e-f68b" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1237,6 +1342,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="89df-5ba8-5989-2ff0" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1249,6 +1355,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1256,6 +1363,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="748c-126a-41a9-6e54" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1272,6 +1380,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e429-daa6-3d15-0860" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1284,6 +1393,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1291,6 +1401,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="79e7-7ddf-a7f2-d721" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
@@ -1307,6 +1418,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1f64-b27e-78e6-5f00" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1319,6 +1431,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1326,6 +1439,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1348,6 +1462,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1355,9 +1470,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4255-a125-b8e7-427a" name="Peasants (32 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="27f1-736e-c78c-c79a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1375,6 +1494,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ddb3-b98b-1b35-1ffb" name="Peasant Yeoman" hidden="false" collective="false" type="model">
@@ -1389,6 +1509,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1405,6 +1526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de67-af2c-c065-a27d" name="Pitchforks, Bills or Glaives" hidden="false" collective="false" type="upgrade">
@@ -1420,6 +1542,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ba62-b8d8-499b-8026" name="Cudgel &amp; Slings" hidden="false" collective="false" type="upgrade">
@@ -1436,6 +1559,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1443,9 +1567,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f319-8ba2-6e61-a9fc" name="Flagellants (92 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="412f-bfb8-a4ae-9814" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="462f-3819-73cc-0390" name="Zealous" hidden="false" targetId="45bb-28cf-94fd-f899" type="rule"/>
@@ -1464,6 +1592,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1480,6 +1609,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b79-f7e1-d195-a1ea" name="Flagellant" hidden="false" collective="false" type="model">
@@ -1492,6 +1622,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1507,6 +1638,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1514,9 +1646,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7eb6-cd0d-3dbe-5a46" name="Ballista (69 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="f024-ace8-02e5-ce3b" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="d978-1b52-1278-001d" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1545,6 +1681,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1552,6 +1689,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2dc5-a742-133a-892e" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1568,6 +1706,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1575,6 +1714,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1591,6 +1731,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad99-64ce-8898-64d1" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -1599,6 +1740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1615,6 +1757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3a5f-e63e-ac56-defd" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1630,6 +1773,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1646,6 +1790,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1653,9 +1798,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f0c0-2cef-09ea-cd94" name="Mangonel (81 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="c5e5-22a4-b8ec-6bf1" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="2693-e158-7240-eec4" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1684,6 +1833,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1691,6 +1841,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fa22-06bf-2135-79bf" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1707,6 +1858,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1714,6 +1866,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1730,6 +1883,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7f2d-d797-1367-9eeb" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -1738,6 +1892,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="75.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1754,6 +1909,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4f97-a2d2-e312-c471" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1769,6 +1925,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1776,9 +1933,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f453-102d-f811-3d2f" name="Mounted Retainers (72 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2794-5bf8-26f4-0118" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -1807,6 +1968,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fd88-c56c-36a4-bbd2" name="Retainer, Riding Horse" hidden="false" collective="false" type="model">
@@ -1819,6 +1981,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1826,6 +1989,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eadb-b8bb-8741-0d60" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1843,6 +2007,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="69de-a24a-1a97-aaa0" name="Retainer, Riding Horse" hidden="false" collective="false" type="model">
@@ -1855,6 +2020,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1862,6 +2028,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1884,6 +2051,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b18-b397-ded2-1804" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -1899,6 +2067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1915,6 +2084,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="afc0-544a-8a60-8fc3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1923,6 +2093,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fba9-9109-7b43-803d" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -1938,6 +2109,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1945,9 +2117,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ddfa-279f-4b28-fb6a" name="Knights on Warhorses (96 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="97b8-a305-e7d0-7794" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -1968,6 +2144,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="40.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f8ad-f5f3-c04b-89bb" name="Knight, Riding Warhorse" hidden="false" collective="false" type="model">
@@ -1980,6 +2157,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2000,6 +2178,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2016,6 +2195,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5258-8162-38f2-03ea" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2024,6 +2204,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="525e-a9b5-dd1d-95f8" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -2032,6 +2213,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b99-92cf-8f8c-a176" name="Warhammer" hidden="false" collective="false" type="upgrade">
@@ -2040,6 +2222,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="13bc-a627-29f3-7dd0" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -2055,6 +2238,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2062,9 +2246,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="634f-e1a7-3261-1cb3" name="Priest (64pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2259-e30c-15f2-5d27" type="max"/>
       </constraints>
@@ -2096,6 +2284,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="64.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ad0c-8963-dd95-1834" name="Supplicant" hidden="false" collective="false" type="model">
@@ -2107,6 +2296,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2114,6 +2304,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8381-b890-cfbf-5149" name="Hair Shirt Armour Upgrade" hidden="false" collective="false" type="upgrade">
@@ -2134,6 +2325,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="74.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1ff2-5e03-69dc-e75c" name="Supplicant" hidden="false" collective="false" type="model">
@@ -2145,6 +2337,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2152,6 +2345,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2168,6 +2362,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e6e-07f5-507a-a342" name="Insufferably Sanctimonious (Tough 2)" hidden="false" collective="false" type="upgrade">
@@ -2176,6 +2371,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2191,6 +2387,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="34c1-fc8d-c37e-265e" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2199,6 +2396,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95ab-4993-696f-b1d6" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2207,6 +2405,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58a8-95c6-cd47-b2d3" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2215,6 +2414,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c984-fb5e-6157-f5fa" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2223,6 +2423,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b362-21f8-9320-c5dd" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2231,6 +2432,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5c8c-b804-9281-c4b6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2239,6 +2441,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2246,9 +2449,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8927-f10c-9b13-777a" name="Knightly Chamption" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c16-c59b-9330-4278" type="max"/>
       </constraints>
@@ -2273,6 +2480,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2288,6 +2496,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2304,6 +2513,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7142-85d5-6100-3b00" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2312,6 +2522,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2328,6 +2539,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02b6-e293-1eaa-aa89" name="Upgrade to Wound 3" hidden="false" collective="false" type="upgrade">
@@ -2336,6 +2548,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ac9-b8b0-e85a-dcaf" name="Wound" hidden="false" collective="false" type="upgrade">
@@ -2344,6 +2557,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2359,6 +2573,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bbd3-01a1-1f47-338b" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2367,6 +2582,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6002-14c0-1adb-94cc" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2375,6 +2591,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99cb-1ec6-2f3b-b47b" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2383,6 +2600,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bbf9-0621-c970-a187" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2391,6 +2609,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2bff-c278-4a7a-a0c0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2399,6 +2618,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b0da-20ef-e2f7-4d9c" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2407,6 +2627,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2414,9 +2635,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="96.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="21a8-e570-5189-b243" name="Mounted Lord Knight (128 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="7ac0-7f8a-f5e0-58c6" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="921e-59fc-b679-c149" name="Mounted Unit" hidden="false" targetId="mounted unit" primary="false"/>
@@ -2436,6 +2661,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="88.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2e7d-6a10-5f2d-6186" name="Knights, Riding Horse" hidden="false" collective="false" type="model">
@@ -2449,6 +2675,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2465,6 +2692,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad2a-cd99-78eb-2e2e" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2473,6 +2701,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1605-9eb3-ff1b-cf99" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -2488,6 +2717,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2510,6 +2740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2526,6 +2757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="134a-2a30-4126-b981" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2534,6 +2766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2550,6 +2783,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5763-1cd3-5807-b782" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2558,6 +2792,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2581,6 +2816,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc56-e07d-912e-4ec7" name="Regular Horses" hidden="false" collective="false" type="upgrade">
@@ -2589,6 +2825,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2604,6 +2841,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4a8c-a520-95bf-f664" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2612,6 +2850,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="01a5-b233-5dc6-1855" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2620,6 +2859,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9611-8723-3219-ca80" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2628,6 +2868,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e372-fa4b-f227-9512" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2636,6 +2877,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fb2f-c702-fc87-989d" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2644,6 +2886,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="14c4-c81e-9719-ce60" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2652,6 +2895,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2659,9 +2903,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="671a-408e-2386-3c7e" name="Lord Knight (106 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="afab-21d2-59da-ee82" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
       </categoryLinks>
@@ -2681,6 +2929,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="78.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac70-dd1d-aa51-2021" name="Knights" hidden="false" collective="false" type="model">
@@ -2693,6 +2942,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2709,6 +2959,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2cc5-0e7a-0c1e-5053" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2717,6 +2968,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66b0-aaf8-4e03-e8f6" name="Chain Mace" hidden="false" collective="false" type="upgrade">
@@ -2725,6 +2977,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4703-1bb9-d4cc-e959" name="Morning Star" hidden="false" collective="false" type="upgrade">
@@ -2733,6 +2986,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b9a-a7d1-e934-6569" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -2741,6 +2995,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="848d-5c98-7dbb-3651" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -2749,6 +3004,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2768,6 +3024,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2784,6 +3041,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a74e-66c0-e86b-e60c" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2792,6 +3050,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2808,6 +3067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df6b-4c99-d4a9-bc16" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2816,6 +3076,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2831,6 +3092,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62b6-feac-9c47-e8e3" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2839,6 +3101,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="61c7-1d0a-eee4-ea38" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2847,6 +3110,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="511a-0396-1178-9bd1" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2855,6 +3119,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f9f1-6634-a352-cd12" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2863,6 +3128,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55c2-c307-547b-2719" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2871,6 +3137,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f92-e097-7f60-5a03" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2879,6 +3146,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2886,6 +3154,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Monsters.cat
+++ b/Monsters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ce73-81f1-52bf-8170" name="Monsters" revision="1" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ce73-81f1-52bf-8170" name="Monsters" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="359d-f1ed-6ac3-3016" name="Basilisk [158/178/198 pts]" hidden="false" collective="false" targetId="c7ea-f805-9726-6682" type="selectionEntry"/>
     <entryLink id="a95f-fd53-c1f1-9ece" name="Chimera [158/178/198 pts]" hidden="false" collective="false" targetId="ba39-ac09-15fb-f789" type="selectionEntry"/>
@@ -30,6 +30,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="c7ea-f805-9726-6682" name="Basilisk [158/178/198 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="b50b-63c0-d15b-5fae" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="94e4-ce18-68ed-b342" name="Baleful Glare" hidden="false" targetId="9855-31c9-3745-714d" type="rule"/>
@@ -49,16 +52,19 @@
             <selectionEntry id="c5a7-8e57-be4d-8c80" name="Wild Basilisk" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="158.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f3a3-9d1c-83ee-c624" name="Bound Basilisk" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="178.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1e81-3fb8-f486-f5a1" name="Allied Basilisk" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="198.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -66,9 +72,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ba39-ac09-15fb-f789" name="Chimera [158/178/198 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="007f-9486-f0f3-1f73" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="2304-6feb-8524-6d85" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -89,16 +99,19 @@
             <selectionEntry id="3a95-41d5-222d-e969" name="Wild Chimera" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="158.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8808-6e3a-105b-97fd" name="Bound Chimera" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="178.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18bd-1699-eadd-7ec2" name="Allied Chimera" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="198.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -114,6 +127,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -121,9 +135,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b01e-a8c7-82df-f6d8" name="Cockatrice [157/177/197 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="e451-e901-db8e-53bf" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="3268-1191-9ede-35f1" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -144,16 +162,19 @@
             <selectionEntry id="9bd8-50f1-127a-f210" name="Wild Cockatrice" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="157.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f172-d87b-3cae-700e" name="Bound Cockatrice" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="177.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e24a-ce4c-dde1-1d35" name="Allied Cockatrice" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="197.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -161,9 +182,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5b3b-b3f4-bbba-7609" name="Cyclops [150/170/190 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="31ea-673a-7d1d-8b0c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5057-ca34-d221-9d56" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -182,16 +207,19 @@
             <selectionEntry id="547a-d807-5442-8c10" name="Wild Cyclops" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="150.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e40a-8db7-c5c6-195b" name="Bound Cyclops" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="170.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7ec1-cc0d-fdd1-13cb" name="Allied Cyclops" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="190.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -207,6 +235,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -214,9 +243,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6617-5ad0-1f45-cbe3" name="Dragon [380/410/440 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="3.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="43bd-198f-38f9-4937" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5e9d-c84f-74ac-7e57" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -239,16 +272,19 @@
             <selectionEntry id="3e21-a58d-f9ab-e3b0" name="Wild Dragon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="380.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="39d6-1fc9-414d-1bd6" name="Bound Dragon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="410.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f91-1fec-a33b-76e9" name="Allied Dragon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="440.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -264,6 +300,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -279,6 +316,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -291,6 +329,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -303,6 +342,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -310,9 +350,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ff4-044a-e595-a1b7" name="Ghouls [85/95/105 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="26c9-5596-ea23-5088" name="Ghouls" hidden="false" targetId="7b72-6afa-c85b-64c1" type="profile"/>
       </infoLinks>
@@ -338,6 +382,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -359,6 +404,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -366,6 +412,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="85.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ae9e-2739-5689-b484" name="Bound Ghouls" hidden="false" collective="false" type="upgrade">
@@ -379,6 +426,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -386,6 +434,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58b1-de83-d5ce-5f03" name="Allied Ghouls" hidden="false" collective="false" type="upgrade">
@@ -399,6 +448,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -406,6 +456,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="105.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -418,6 +469,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -425,9 +477,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4fea-a33c-4fc3-b70b" name="Giant [253/283/313 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="3.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="67ff-6c49-1de3-34e7" name="Giant" hidden="false" targetId="e5bb-3c2b-9a60-9c05" type="profile"/>
         <infoLink id="cb89-14df-4900-c743" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -448,16 +504,19 @@
             <selectionEntry id="69bc-e6b8-ecbd-ab78" name="Wild Giant" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="253.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="735b-b165-3df7-5fe6" name="Bound Giant" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="283.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3ede-d6a0-25b7-5eb0" name="Allied Giant" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="313.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -473,6 +532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -488,6 +548,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -495,9 +556,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d456-6e73-d1fc-5db4" name="Giant Rats [46/56/66 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="fcb1-715e-dd6d-1648" name="Giant Rats" hidden="false" targetId="cd05-6e8f-63cf-f6ad" type="profile"/>
         <infoLink id="2af1-c96c-56d5-a957" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
@@ -523,6 +588,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -530,6 +596,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="46.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9ff-9571-4ea4-40e6" name="Bound Giant Rats" hidden="false" collective="false" type="upgrade">
@@ -543,6 +610,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -550,6 +618,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="56.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="48e8-ed6c-33e2-7806" name="Allied Giant Rats" hidden="false" collective="false" type="upgrade">
@@ -563,6 +632,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -570,6 +640,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="66.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -582,6 +653,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -589,9 +661,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="452a-2a19-4531-92b8" name="Giant Scorpions [57/67/77 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="41f0-23ba-bb43-390b" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
         <infoLink id="a718-0d20-0e0d-3d45" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
@@ -618,6 +694,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -625,6 +702,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="57.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f4d0-49aa-8e85-20c3" name="Bound Giant Scorpions" hidden="false" collective="false" type="upgrade">
@@ -638,6 +716,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -645,6 +724,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="67.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27b3-fd62-b1f5-fb6a" name="Allied Giant Scorpions" hidden="false" collective="false" type="upgrade">
@@ -658,6 +738,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -665,6 +746,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="77.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -677,6 +759,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="59.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -684,9 +767,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="051b-44ef-ec3d-a1c1" name="Giant Spiders [50/60/70 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="bcb1-41fa-2bc3-7fe0" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
         <infoLink id="d2e8-3189-34b5-3822" name="Giant Spiders" hidden="false" targetId="70ab-0608-068e-a498" type="profile"/>
@@ -712,6 +799,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -719,6 +807,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44f6-eaa3-c092-6ede" name="Bound Giant Spiders" hidden="false" collective="false" type="upgrade">
@@ -732,6 +821,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -739,6 +829,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5bf-349f-7dd0-f647" name="Allied Giant Spiders" hidden="false" collective="false" type="upgrade">
@@ -752,6 +843,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -759,6 +851,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="70.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -771,6 +864,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="52.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -778,9 +872,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2846-5918-fd84-7e29" name="Gigantic Spider [218/238/258 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="8ffb-7b41-1748-a62a" name="Gigantic Spider" hidden="false" targetId="ca3a-b6cb-8358-d7d9" type="profile"/>
         <infoLink id="0d8b-3229-a256-b8c6" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -800,16 +898,19 @@
             <selectionEntry id="89a1-e66a-a003-4cd8" name="Wild Gigantic Spider" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="218.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c54e-49dc-5a0c-3fbc" name="Bound Gigantic Spider" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="238.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ee0-30cf-e562-3f38" name="Allied Gigantic Spider" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="258.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -825,6 +926,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -832,9 +934,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7835-8a79-e484-397e" name="Golem [64 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="9df5-9e0f-f770-8a7c" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="1912-83de-49d8-38e3" name="Golem" hidden="false" targetId="ec10-cee9-9e3f-9783" type="profile"/>
@@ -854,6 +960,7 @@
             <selectionEntry id="1897-fb06-b190-6c50" name="Bound Golem" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="64.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -869,6 +976,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -876,9 +984,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b90a-e799-9047-9183" name="Griffin [144/164/184 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="ba6c-b5a4-87d6-9244" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="b17f-aa01-9b6f-27b9" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -900,16 +1012,19 @@
             <selectionEntry id="a3bf-db9b-f57b-6e62" name="Wild Griffin" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="144.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b370-b36b-43ca-a71c" name="Bound Griffon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="164.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b331-fbf6-1c50-ebee" name="Allied Griffin" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="184.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -917,9 +1032,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="30d1-8869-3361-d27b" name="Hippogriff [138/159/179 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="1fae-240f-11ae-1659" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="794e-15ba-aeff-8c62" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -940,16 +1059,19 @@
             <selectionEntry id="70a7-aa27-b130-ad73" name="Wild Hippogriff" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="138.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c8c8-e773-51c3-6cee" name="Bound Hippogriff" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="159.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3a43-2059-fef8-b1b2" name="Allied Hippogriff" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="179.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -957,9 +1079,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1826-be4d-e802-d903" name="Hydra [182/202/222 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="50a9-c5bc-9431-4e0a" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="bd23-8ea6-af19-6925" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -980,16 +1106,19 @@
             <selectionEntry id="cb50-75bc-b388-29f5" name="Wild Hydra" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="182.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a1ee-e6d1-d095-f330" name="Bound Hydra" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="202.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed64-f50f-d38e-3488" name="Allied Hydra" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="222.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1006,6 +1135,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1021,6 +1151,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1028,9 +1159,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3c5b-7264-8586-c81c" name="Manticore [158/178/198 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="82a1-b369-5dad-45a8" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="c30c-22bf-14f9-b0a7" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1049,16 +1184,19 @@
             <selectionEntry id="944c-8f6d-0c3c-2775" name="Wild Manticore" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="158.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b02e-ae6c-1e3f-9414" name="Bound Manticore" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="178.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5f8a-a49e-21b5-2691" name="Allied Manticore" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="198.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1074,6 +1212,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1093,6 +1232,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da4b-100f-1b25-b303" name="Manticore" hidden="false" collective="false" type="upgrade">
@@ -1102,15 +1242,23 @@
               <infoLinks>
                 <infoLink id="53fc-6c57-de7f-c9d6" name="Manticore" hidden="false" targetId="3bd1-e1ac-0073-8b2f" type="profile"/>
               </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bdbd-2e9c-63ce-9620" name="Ogres [28/38/48 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="a08d-bc50-05c7-48a5" name="Frenzied Charge" hidden="false" targetId="1c49-276e-425d-0999" type="rule"/>
         <infoLink id="dbec-2695-bc32-575e" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1128,16 +1276,19 @@
             <selectionEntry id="10fd-618a-e4ea-206c" name="Wild" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95ed-5dcf-9a9f-723c" name="Bound" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="84ab-9d2d-9bd0-f9f9" name="Allied" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1162,6 +1313,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1169,6 +1321,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="49d4-9052-fe2a-c388" name="Ogres in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1185,6 +1338,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1192,6 +1346,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1208,6 +1363,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96a6-d255-dca8-5529" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -1216,6 +1372,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce2a-712b-0058-45d6" name="Warhammer" hidden="false" collective="false" type="upgrade">
@@ -1224,6 +1381,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c4b-eb71-1dbf-f127" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1232,6 +1390,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1251,6 +1410,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1258,9 +1418,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="71af-c82c-450e-2b37" name="Wild Swarms [75 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d22a-534c-0358-514b" name="New CategoryLink" hidden="false" targetId="c820-d327-811d-1144" primary="true"/>
       </categoryLinks>
@@ -1278,6 +1442,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="22d1-b18d-b1a9-e05c" name="Batswarm" hidden="false" collective="false" type="upgrade">
@@ -1288,6 +1453,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b3f8-e4f3-9d0f-6baa" name="Spiderswarm" hidden="false" collective="false" type="upgrade">
@@ -1296,6 +1462,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5baa-7f1c-6d03-a96e" name="Frogswarm" hidden="false" collective="false" type="upgrade">
@@ -1305,6 +1472,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3259-16f8-1a76-b829" name="Beeswarm" hidden="false" collective="false" type="upgrade">
@@ -1315,6 +1483,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3291-9eba-d0a4-e5d7" name="Serpentswarm" hidden="false" collective="false" type="upgrade">
@@ -1325,6 +1494,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1338,6 +1508,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1345,9 +1516,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5943-a398-3d77-7af7" name="Wyvern [160/180/200 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="8047-0ae2-5fde-30a9" name="Wyvern " hidden="false" targetId="c844-35e2-768e-50f8" type="profile"/>
         <infoLink id="e741-a542-0958-f574" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1367,16 +1542,19 @@
             <selectionEntry id="3692-feb9-6467-959f" name="Wild Wyvern" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="160.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dfe9-9eec-b034-aa25" name="Bound Wyvern" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="180.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8f81-0caf-1d01-ec4b" name="Allied Wyvern" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="200.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1393,6 +1571,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96dd-35c0-46c4-15f6" name="Beastly Breath" hidden="false" collective="false" type="upgrade">
@@ -1401,6 +1580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1417,6 +1597,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d229-e8a7-8781-1915" name="Venomous" hidden="false" collective="false" type="upgrade">
@@ -1425,6 +1606,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1432,9 +1614,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="853f-a790-4f4e-0d98" name="Allied Giant Treeman [204 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="ca7a-c26f-0c79-0909" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="d13a-f5db-2a1a-6350" name="Blundering" hidden="false" targetId="087e-dfda-76c2-09bf" type="rule"/>
@@ -1460,6 +1646,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="204.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1475,6 +1662,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1482,9 +1670,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6491-3e79-cfd5-76db" name="Allied Treemen/Dryads" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="8bc0-6f99-fbe7-77ca" name="Blundering" hidden="false" targetId="087e-dfda-76c2-09bf" type="rule"/>
         <infoLink id="4bb4-42a6-3f94-eca5" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1509,6 +1701,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="53.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f347-3d89-8a61-7e10" name="Additional Treemen/Dryads" hidden="false" collective="false" type="model">
@@ -1517,6 +1710,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="33.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1524,9 +1718,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="45c6-60cf-f892-7efa" name="Trolls [105/115 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="9a36-64d4-76ed-3e08" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5d10-c992-7ceb-8196" name="Regenerate" hidden="false" targetId="0a0c-ed4c-9647-4398" type="rule"/>
@@ -1548,6 +1746,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1561,11 +1760,13 @@
             <selectionEntry id="2270-2d2f-e43a-4d4f" name="Wild" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5c2-0b03-6640-007c" name="Bound" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1573,9 +1774,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cfc8-c933-eeab-5e21" name="Cave Bear" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="88c6-0967-6a45-8abc" name="Cave Bear" hidden="false" targetId="da16-d143-b468-26c3" type="profile"/>
         <infoLink id="2201-d7c9-fea8-e342" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1596,11 +1801,13 @@
             <selectionEntry id="8466-565c-872e-39ef" name="Wild Cave Bear" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="21e9-914d-c0a4-f6dd" name="Allied Were Bear" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="82.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1608,9 +1815,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="903f-9d10-4831-bf0f" name="Brontosaur [115/135 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2fcb-45a2-d98b-188f" name="Brontosaur" hidden="false" targetId="5ca4-7d22-6678-4dc5" type="profile"/>
         <infoLink id="eeea-e415-ab59-aba9" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1630,11 +1841,13 @@
             <selectionEntry id="6ee4-fa2e-f18a-e585" name="Wild Brontosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="115.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="93f4-cb20-966f-0aeb" name="Bound Brontosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="135.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1642,9 +1855,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4f7e-f547-4d5a-8c7c" name="Tyrannosaur [188/208 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="0a43-75c0-306c-dc81" name="Tyrannosaur" hidden="false" targetId="c74b-e0c7-6a3d-bc2a" type="profile"/>
         <infoLink id="ee39-5489-a196-f333" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1665,11 +1882,13 @@
             <selectionEntry id="2346-0528-6126-5d9f" name="Wild Tyrannosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="188.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c57-a04b-6fb8-7f01" name="Bound Tyrannosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="208.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1677,9 +1896,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3aff-bbec-a820-725d" name="Horned Dinosaur [122/142 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="fe58-085f-9e71-bc8e" name="Horned Dinosaur" hidden="false" targetId="68aa-6640-b9da-6ee0" type="profile"/>
         <infoLink id="307f-3fd4-9ab7-6ece" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1700,11 +1923,13 @@
             <selectionEntry id="09d1-5c85-75f4-4881" name="Wild Horned Dinosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="122.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="12dd-9ea6-8083-cb4a" name="Bound Horned Dinosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="142.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1712,6 +1937,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -1722,7 +1948,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="9f01-a520-920a-bd90" name="Basilisk" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="9f01-a520-920a-bd90" name="Basilisk" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">4</characteristic>
@@ -1733,7 +1959,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV4, Baleful Glare, Dread</characteristic>
       </characteristics>
     </profile>
-    <profile id="2dbb-4ea1-5f93-dce3" name="Chimera" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="2dbb-4ea1-5f93-dce3" name="Chimera" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">4</characteristic>
@@ -1744,7 +1970,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD 2, 4xHTH SV4, 1xHTH SV10 Venomous, 3xFlaming Breath SV3 Fire, Dread</characteristic>
       </characteristics>
     </profile>
-    <profile id="0184-c48d-2234-cbf7" name="Cockatrice" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="0184-c48d-2234-cbf7" name="Cockatrice" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">4</characteristic>
@@ -1755,7 +1981,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH Attacks SV3, Baleful Glare, Dread, Flies</characteristic>
       </characteristics>
     </profile>
-    <profile id="fdd9-726d-86fe-ec2d" name="Cyclops" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="fdd9-726d-86fe-ec2d" name="Cyclops" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -1775,7 +2001,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Overhead, Fire Order to Shoot, D6 hits</characteristic>
       </characteristics>
     </profile>
-    <profile id="51fb-1d59-eff1-b671" name="Dragon" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="51fb-1d59-eff1-b671" name="Dragon" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">4</characteristic>
@@ -1786,7 +2012,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD3, Fast 6, 7xHTH SV6, 3xFlaming Breath SV3 Fire, Dread, Terror, Flies</characteristic>
       </characteristics>
     </profile>
-    <profile id="7b72-6afa-c85b-64c1" name="Ghouls" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="7b72-6afa-c85b-64c1" name="Ghouls" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1797,7 +2023,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHTH SV1</characteristic>
       </characteristics>
     </profile>
-    <profile id="e5bb-3c2b-9a60-9c05" name="Giant" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="e5bb-3c2b-9a60-9c05" name="Giant" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -1808,7 +2034,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD3, 5xHTH SV5, Dread, Terror, Blundering</characteristic>
       </characteristics>
     </profile>
-    <profile id="cd05-6e8f-63cf-f6ad" name="Giant Rats" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="cd05-6e8f-63cf-f6ad" name="Giant Rats" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1819,7 +2045,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHTH SV1 Venomous</characteristic>
       </characteristics>
     </profile>
-    <profile id="9cd1-3fa7-9244-5170" name="Giant Scorpions" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="9cd1-3fa7-9244-5170" name="Giant Scorpions" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1830,7 +2056,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHTH SV2, 1xHTH SV10, Venomous, Wound</characteristic>
       </characteristics>
     </profile>
-    <profile id="70ab-0608-068e-a498" name="Giant Spiders" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="70ab-0608-068e-a498" name="Giant Spiders" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1841,7 +2067,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV3, Wound</characteristic>
       </characteristics>
     </profile>
-    <profile id="ca3a-b6cb-8358-d7d9" name="Gigantic Spider" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="ca3a-b6cb-8358-d7d9" name="Gigantic Spider" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1852,7 +2078,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 6xHTH SV6, Dread, Terror</characteristic>
       </characteristics>
     </profile>
-    <profile id="ec10-cee9-9e3f-9783" name="Golem" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="ec10-cee9-9e3f-9783" name="Golem" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">3</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1863,7 +2089,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Slow 4, 3xHTH SV2, Dread</characteristic>
       </characteristics>
     </profile>
-    <profile id="61f2-9f86-a3d8-d5e8" name="Griffin" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="61f2-9f86-a3d8-d5e8" name="Griffin" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1874,7 +2100,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV3, Dread, Savage, Fast 6, Flies</characteristic>
       </characteristics>
     </profile>
-    <profile id="7ea6-624e-3017-99b2" name="Hippogriff" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="7ea6-624e-3017-99b2" name="Hippogriff" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1885,7 +2111,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV3, Dread, Fast 6, Flies</characteristic>
       </characteristics>
     </profile>
-    <profile id="6e13-9d18-f7c2-d272" name="Hydra" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="6e13-9d18-f7c2-d272" name="Hydra" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -1896,7 +2122,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 9xHTH SV2, Stubborn, Dread, Regenerate</characteristic>
       </characteristics>
     </profile>
-    <profile id="3bd1-e1ac-0073-8b2f" name="Manticore" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="3bd1-e1ac-0073-8b2f" name="Manticore" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -1907,7 +2133,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV4, Beastly breath, Dread</characteristic>
       </characteristics>
     </profile>
-    <profile id="c57c-29b1-6dce-2cb0" name="Ogres" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="c57c-29b1-6dce-2cb0" name="Ogres" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -1918,7 +2144,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 2xHTH, Frenzied Charge</characteristic>
       </characteristics>
     </profile>
-    <profile id="4c9f-6aab-32b0-d91d" name="Ogres in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="4c9f-6aab-32b0-d91d" name="Ogres in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -1929,7 +2155,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 2xHTH, Frenzied Charge</characteristic>
       </characteristics>
     </profile>
-    <profile id="e8bd-7b95-1cce-09a4" name="Wild Ratswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="e8bd-7b95-1cce-09a4" name="Wild Ratswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1940,7 +2166,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV1 Venomous</characteristic>
       </characteristics>
     </profile>
-    <profile id="3476-9800-ad47-8c84" name="Wild Batswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="3476-9800-ad47-8c84" name="Wild Batswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1951,7 +2177,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV1, Flies, Fast 7</characteristic>
       </characteristics>
     </profile>
-    <profile id="ed6e-31c3-36b2-839f" name="Wild Spiderswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="ed6e-31c3-36b2-839f" name="Wild Spiderswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1962,7 +2188,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">4xHTH SV0</characteristic>
       </characteristics>
     </profile>
-    <profile id="1611-c370-3e68-d00a" name="Wild Frogswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="1611-c370-3e68-d00a" name="Wild Frogswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1973,7 +2199,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV0, Dread</characteristic>
       </characteristics>
     </profile>
-    <profile id="5319-4ee6-a650-6292" name="Wild Beeswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="5319-4ee6-a650-6292" name="Wild Beeswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1984,7 +2210,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV0, Venomous, Flies</characteristic>
       </characteristics>
     </profile>
-    <profile id="bb99-778c-b54b-3569" name="Wild Serpentswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="bb99-778c-b54b-3569" name="Wild Serpentswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -2083,7 +2309,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 3xHTH SV5, Dread, Stampede, Irresistable Charge</characteristic>
       </characteristics>
     </profile>
-    <profile id="c9d3-d13d-232c-c354" name="Manticore with Stinging Tail" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="c9d3-d13d-232c-c354" name="Manticore with Stinging Tail" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>

--- a/Olympians.cat
+++ b/Olympians.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c443-9f03-53ab-b315" name="Olympians" revision="1" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c443-9f03-53ab-b315" name="Olympians" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="5603-81f3-5a9e-eea9" name="Centaurs" hidden="false" collective="false" targetId="4b29-f094-4487-eb77" type="selectionEntry"/>
     <entryLink id="2b37-6ff6-a421-0732" name="Harpies" hidden="false" collective="false" targetId="8ea4-dd34-63f1-1949" type="selectionEntry"/>
@@ -17,6 +17,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4b29-f094-4487-eb77" name="Centaurs [108 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="6d56-3a8a-443b-e633" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5b20-0eb3-f58b-f834" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
@@ -45,6 +48,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1f6c-92bc-a542-b088" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -58,6 +62,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="44.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -65,6 +70,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fed1-4788-3778-d1c3" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -81,6 +87,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6d65-1bb4-924d-33ab" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -94,6 +101,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="46.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -101,6 +109,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc5f-1cad-533c-b3a5" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -117,6 +126,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="36.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e5dc-b593-096e-f370" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -130,6 +140,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="48.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -137,6 +148,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -153,6 +165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8659-e294-65da-e09d" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -168,6 +181,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0f4-3f97-65d3-cc5c" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -183,6 +197,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ccf-43bb-e01b-8e9f" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -198,6 +213,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55b8-b817-7be1-bd04" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -213,6 +229,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -235,6 +252,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -250,6 +268,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -257,9 +276,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8ea4-dd34-63f1-1949" name="Harpies [150 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="8333-5201-5ef4-5f8e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="4a1e-a520-cd6f-58be" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
@@ -279,6 +302,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -294,6 +318,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -316,6 +341,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -323,9 +349,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1cf2-13c4-d6c2-a87c" name="Amazon Cavalry [75 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="72d9-bd60-6bcc-e9cc" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -353,6 +383,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d2b1-3769-9188-ee98" name="Amazon Cavalry Leader" hidden="false" collective="false" type="model">
@@ -366,6 +397,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="33.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -373,6 +405,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f68-9b78-71d3-fe73" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -389,6 +422,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ce00-03e7-d2be-a4e5" name="Amazon Cavalry Leader" hidden="false" collective="false" type="model">
@@ -402,6 +436,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="35.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -409,6 +444,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -424,6 +460,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -446,6 +483,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -462,6 +500,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e0a7-eb58-36e3-3df4" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -470,6 +509,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -477,9 +517,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dddc-a18c-2b9c-5157" name="Amazon Archers [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="92f7-1bc1-3605-3c1e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -504,6 +548,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="37d2-67c2-4301-fe42" name="Amazon Archer Leader" hidden="false" collective="false" type="model">
@@ -517,6 +562,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -524,6 +570,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="edc1-772f-abcf-ff39" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -540,6 +587,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="08a0-19a2-2b4d-7bd2" name="Amazon Archer Leader" hidden="false" collective="false" type="model">
@@ -553,6 +601,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -560,6 +609,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -576,6 +626,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87b4-91df-44ff-c7d2" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -584,6 +635,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -599,6 +651,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -615,6 +668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee7d-cc9b-1fb5-521e" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -630,6 +684,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -637,9 +692,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="405c-428f-c19e-d4b8" name="Amazon Warrior [77 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="4efa-2b8c-ee61-efcf" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -664,6 +723,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b2ca-1fb5-ac9b-55a3" name="Amazon Warrior Leader" hidden="false" collective="false" type="model">
@@ -677,6 +737,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -684,6 +745,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc31-9f8a-2ef9-ab1d" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -700,6 +762,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4331-be6f-a01b-5d23" name="Amazon Warrior Leader" hidden="false" collective="false" type="model">
@@ -713,6 +776,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -720,6 +784,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -736,6 +801,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c730-e02f-6b6b-def5" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -744,6 +810,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f58c-efbe-33e3-aa6a" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -752,6 +819,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -759,9 +827,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d1e5-7b9c-70d2-9356" name="Peltast [67 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="f96a-0da1-16cb-8807" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -785,11 +857,13 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dea1-c75f-4108-c061" name="Daggers" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -806,6 +880,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f7f-7277-0b9d-804c" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -821,6 +896,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c396-7a82-7391-93f8" name="Javelin" hidden="false" collective="false" type="upgrade">
@@ -829,6 +905,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -853,6 +930,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f3dd-d202-b517-9d76" name="Peltast Leader" hidden="false" collective="false" type="model">
@@ -866,6 +944,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -873,6 +952,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="28b6-05ee-3a6c-de1d" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -889,6 +969,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8e71-f7d7-47ef-be27" name="Peltast Leader" hidden="false" collective="false" type="model">
@@ -902,6 +983,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -909,6 +991,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -916,9 +999,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ca9d-82e1-bcde-c147" name="Hoplites [82 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2ae1-694c-cae3-8bfb" name="Shieldwall" hidden="false" targetId="93f9-d132-d71b-ab39" type="rule"/>
         <infoLink id="ce89-2730-d206-62e7" name="Long Spears" hidden="false" targetId="8c77-0a0d-0097-c499" type="profile"/>
@@ -940,6 +1027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2137-fb2b-2d44-5821" name="Hoplite" hidden="false" collective="false" type="model">
@@ -952,6 +1040,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -967,6 +1056,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -974,9 +1064,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0ff7-a68e-abb3-2793" name="Hopolite Guard [92 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="0ff7-a68e-abb3-2793" name="Hoplite Guard [92 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="01c2-4a31-14bb-12f7" name="Shieldwall" hidden="false" targetId="93f9-d132-d71b-ab39" type="rule"/>
         <infoLink id="b441-a7c3-0271-9a78" name="Disciplined" hidden="false" targetId="0056-a41e-408e-1673" type="rule"/>
@@ -998,6 +1092,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4802-8d10-9390-f7bd" name="Hoplite Guard" hidden="false" collective="false" type="model">
@@ -1010,6 +1105,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1026,6 +1122,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3812-552b-cd66-1ac4" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1034,6 +1131,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1049,6 +1147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1056,9 +1155,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d60c-560f-d373-3699" name="Greek Hero Charioteer [160 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e2a-0340-0c74-298d" type="max"/>
       </constraints>
@@ -1083,6 +1186,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd24-795a-5245-caa0" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1091,6 +1195,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53e8-5fbe-f804-2ca5" name="Long Spear" hidden="false" collective="false" type="upgrade">
@@ -1099,6 +1204,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1118,6 +1224,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1135,6 +1242,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="160.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c3b-17ee-f65b-61d8" name="Greek Crew" hidden="false" collective="false" type="upgrade">
@@ -1147,6 +1255,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1162,6 +1271,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1178,6 +1288,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="029f-b0f4-dffa-2cdb" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1186,6 +1297,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1202,6 +1314,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e947-afcf-5c76-9739" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1210,6 +1323,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8165-59f6-47ef-77dd" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1218,6 +1332,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1233,6 +1348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1248,6 +1364,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1263,6 +1380,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="015e-62a6-4767-b1bc" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1271,6 +1389,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91d4-3d5e-5589-2c74" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1279,6 +1398,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7af5-a407-8410-d9f4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1287,6 +1407,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9433-9b02-3de8-0a9c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1295,6 +1416,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2693-7a93-cf46-3dd2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1303,6 +1425,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="452e-f376-7443-e70a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1311,6 +1434,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1318,9 +1442,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a4e6-d616-6bf5-4399" name="Greek Hero [85 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="7d43-8ea1-1e69-297e" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="77d4-95f9-b227-4ffb" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1339,6 +1467,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="85.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1355,6 +1484,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f4b2-0e1b-2414-f81e" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1363,6 +1493,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6bc1-f1d2-1cae-5fe0" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1371,6 +1502,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1387,6 +1519,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df86-aee5-fd04-7711" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1395,6 +1528,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1410,6 +1544,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1425,6 +1560,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1441,6 +1577,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d81-3619-85f7-39e3" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1449,6 +1586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="be9f-4181-78b5-f67d" name="Long Spear" hidden="false" collective="false" type="upgrade">
@@ -1457,6 +1595,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9d56-33b2-5034-86b8" name="Magic Weapon" hidden="false" collective="false" type="upgrade">
@@ -1472,6 +1611,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="20cb-0cb3-281f-4a3f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1480,6 +1620,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5b87-a3c4-5532-a79b" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1488,6 +1629,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5b16-68c9-4178-3044" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1496,6 +1638,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1503,6 +1646,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1518,6 +1662,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6586-968f-967c-db55" name="Ranged Magic Weapons" hidden="false" collective="false" type="upgrade">
@@ -1533,6 +1678,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="14cc-4860-dbe0-9d97" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1541,6 +1687,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="bc8f-2270-db7f-c3d2" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1549,6 +1696,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1556,6 +1704,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1563,9 +1712,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9944-6808-c090-b071" name="Greek Seer [57 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="f5d4-2073-01a6-9983" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
@@ -1587,6 +1740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="57.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1610,6 +1764,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="10.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -1617,6 +1772,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2c94-48f3-1c28-c3a4" name="Nymphs" hidden="false" collective="false" type="unit">
@@ -1632,6 +1788,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="18.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -1639,6 +1796,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -1657,6 +1815,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fe1f-2ccb-1de9-69ce" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -1665,6 +1824,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f652-48eb-158d-9fb4" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -1673,6 +1833,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1688,6 +1849,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1704,6 +1866,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f1bb-ea8e-dc08-2316" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1712,6 +1875,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1728,6 +1892,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ef3a-f4be-bf0f-2e42" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1736,6 +1901,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d8d6-541b-2519-1eaa" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1744,6 +1910,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ee0-a4da-27da-d4ee" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1752,6 +1919,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf0e-31e9-9e83-8275" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1760,6 +1928,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10be-89e3-d278-3d00" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1768,6 +1937,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a559-7b6d-31ea-fbd1" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1776,6 +1946,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4fbc-c531-ebed-7517" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1784,6 +1955,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d7b9-a07d-114b-42b0" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1792,6 +1964,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8ace-64db-3ba2-beaa" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1800,6 +1973,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf86-4221-aa7d-f913" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1808,6 +1982,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d46-75cc-3c7b-01f2" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1816,6 +1991,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee5e-6fa8-a8b9-8385" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1824,6 +2000,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0eaa-1117-e30b-5225" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1832,6 +2009,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1847,6 +2025,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87e6-d673-2db2-d2dd" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1858,6 +2037,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="574d-699d-eb15-4460" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1869,6 +2049,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="218c-171a-3ec5-4bd5" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1880,6 +2061,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0dbb-1a6b-1de1-a241" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1891,6 +2073,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f5d4-6afe-2529-0f68" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1902,6 +2085,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0345-cfff-89bb-a7d9" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1913,6 +2097,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0544-ada4-b675-be92" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1924,6 +2109,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73e8-b412-ab50-f86c" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1935,6 +2121,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="925c-b3cb-0b5e-1cd8" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1946,6 +2133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="772d-10ba-11b7-6b3d" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1957,6 +2145,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9f4-1ca2-ed5d-ea53" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1968,6 +2157,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eb80-c966-5cf6-760d" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1979,6 +2169,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f7df-dc43-ac87-3c31" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1990,6 +2181,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2005,6 +2197,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="867e-0330-18c2-14d2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2013,6 +2206,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd06-9456-6fed-6727" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2021,6 +2215,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b356-d987-f633-0729" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2029,6 +2224,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="504a-aca5-ddc1-55cb" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2037,6 +2233,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98ce-3cb0-1c26-22c4" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2045,6 +2242,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db70-0686-6ad7-54de" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2053,6 +2251,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2060,9 +2259,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a25e-e608-b473-48ab" name="Greek Lord (on foot) [108 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9913-338f-39a1-d10d" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="2933-ff18-cd5c-a919" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -2082,6 +2285,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="76.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b9d-f87a-5da3-a7e1" name="Hoplite Bodyguard" hidden="false" collective="false" type="model">
@@ -2094,6 +2298,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2110,6 +2315,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="75b3-f044-42ad-23d9" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2118,6 +2324,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55d5-2ec9-d047-2767" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2126,6 +2333,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2141,6 +2349,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2156,6 +2365,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2172,6 +2382,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98df-555a-7a9b-89cb" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -2180,6 +2391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2196,6 +2408,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebf0-6d1b-b097-bb73" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2204,6 +2417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2219,6 +2433,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2234,6 +2449,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ec7d-4152-4ede-8027" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2242,6 +2458,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d94-dd96-0692-bc85" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2250,6 +2467,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10a7-7fd7-33d4-b458" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2258,6 +2476,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a756-aa39-cb3f-193c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2266,6 +2485,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3165-bee5-dd88-fc56" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2274,6 +2494,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac68-40d2-f38d-85f2" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2282,6 +2503,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2289,9 +2511,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="75b5-c473-3303-4a2b" name="Greek Lord in Chariot [160 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="bb2a-6035-55ad-ff42" name="Chariot with Greek Lord and Crew, pulled by two horses" hidden="false" targetId="2db3-9b45-d996-8813" type="profile"/>
         <infoLink id="0aae-3177-e9fb-2a12" name="Horse" hidden="false" targetId="1319-8d6e-7092-4ce8" type="profile"/>
@@ -2312,6 +2538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2328,6 +2555,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4548-811e-d803-1608" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2336,6 +2564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7eeb-2813-a7ff-9d13" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2344,6 +2573,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2366,6 +2596,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2381,6 +2612,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2397,6 +2629,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="798f-9529-11d3-3844" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -2405,6 +2638,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2421,6 +2655,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="17e1-f91a-3e53-5239" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2429,6 +2664,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2447,6 +2683,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="160.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d6b0-5018-894f-fa44" name="Greek Crew" hidden="false" collective="false" type="model">
@@ -2459,6 +2696,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2474,6 +2712,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ea77-e77c-046f-21e4" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2482,6 +2721,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad22-777d-1392-ab07" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2490,6 +2730,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c16-07b6-164f-ba4a" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2498,6 +2739,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58cc-80ac-cd62-e905" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2506,6 +2748,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2db2-b1f9-e255-56ae" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2514,6 +2757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1993-b9d7-6983-818d" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2522,6 +2766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2529,6 +2774,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Orcs.cat
+++ b/Orcs.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="048c-0297-6af4-d584" name="Orcs" revision="1" battleScribeVersion="2.02" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="048c-0297-6af4-d584" name="Orcs" revision="2" battleScribeVersion="2.02" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="8a3b-c7ba-275b-f90a" name="Orc Chieftain [95 pts]" hidden="false" collective="false" targetId="782e-229e-cefd-31f5" type="selectionEntry"/>
     <entryLink id="6c83-5f2b-a031-77cf" name="Orc Chieftain Boar Rider [136 pts]" hidden="false" collective="false" targetId="e332-00ba-1c22-d3dc" type="selectionEntry"/>
@@ -16,6 +16,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="782e-229e-cefd-31f5" name="Orc Chieftain [95 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="72c4-1d15-8e4a-a1a8" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="22ab-a8a5-88c4-69d2" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -45,6 +48,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="71.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="22cb-d2e0-78ba-b0a5" name="Orc Bodyguard in Light Armour" hidden="false" collective="false" type="model">
@@ -57,6 +61,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -64,6 +69,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c350-15e9-c8ad-55ac" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -80,6 +86,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="81.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fa3b-ed0b-f01f-da1a" name="Orc Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -92,6 +99,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -99,6 +107,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -115,6 +124,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce01-4393-ee92-5b1c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -123,6 +133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -139,6 +150,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f2e-8f11-9ab6-ba41" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -147,6 +159,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8be1-087b-5bf4-da64" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -155,6 +168,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -171,6 +185,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="65d0-c55a-45c5-b521" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -179,6 +194,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ffb-3b01-02df-8e97" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -187,6 +203,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bdac-1823-d46b-046d" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -195,6 +212,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db07-6a90-6377-33b7" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -210,6 +228,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8224-0d9e-ad75-d6c7" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -225,6 +244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -247,6 +267,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -269,6 +290,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -284,6 +306,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af9f-b698-93b0-617d" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -292,6 +315,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a015-e212-8d4e-5cc7" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -300,6 +324,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ff7-52f7-3285-cb57" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -308,6 +333,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="afee-7c20-bf72-b379" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -316,6 +342,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="01cc-4d7b-dada-85c1" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -324,6 +351,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="40ce-66d1-cf0b-72b5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -332,6 +360,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -339,9 +368,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e332-00ba-1c22-d3dc" name="Orc Chieftain Boar Rider [136 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="7135-41db-ccb4-8cf1" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="3b39-9ecb-7965-8e20" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -373,6 +406,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="86.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d3a2-dbbd-6302-1699" name="Orc Bodyguard in Light Armour" hidden="false" collective="false" type="model">
@@ -385,6 +419,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -392,6 +427,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c7e9-36af-775c-227b" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -408,6 +444,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="96.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fe68-c865-4d3e-4e86" name="Orc Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -420,6 +457,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -427,6 +465,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -443,6 +482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2b16-780a-da64-0220" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -451,6 +491,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -467,6 +508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9727-7111-4415-a13f" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -475,6 +517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c87-803d-c81f-2694" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -483,6 +526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -499,6 +543,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1232-1b53-c2b6-57f2" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -507,6 +552,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a96b-c9db-a090-8c24" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -515,6 +561,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f47-e87f-b915-fd72" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -523,6 +570,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e49d-73c2-890b-e156" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -538,6 +586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e009-f8df-7e28-108c" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -553,6 +602,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -575,6 +625,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -590,6 +641,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8662-f304-1eda-5b73" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -598,6 +650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bbc1-3e69-6f77-0f1e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -606,6 +659,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="28f0-2e30-9282-7204" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -614,6 +668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e6a3-2ce8-277e-83d0" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -622,6 +677,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="59e5-71ec-e493-c9dc" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -630,6 +686,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1cc5-9098-5821-51ab" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -638,6 +695,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -645,9 +703,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8507-c9fb-4724-e2b5" name="Orc Shaman [57 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64bb-c692-2a23-a111" type="max"/>
       </constraints>
@@ -671,6 +733,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="57.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -686,6 +749,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -702,6 +766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a6b8-4549-e050-eac3" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -710,6 +775,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3e13-a469-4ff8-c0ef" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -718,6 +784,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -734,6 +801,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5e0a-b73d-5608-1121" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -742,6 +810,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="871f-7b0a-926b-2a3a" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -750,6 +819,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ebe-7e78-78f8-64f1" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -758,6 +828,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -774,6 +845,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3714-2a9e-7cfe-9237" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -782,6 +854,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -804,6 +877,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -819,6 +893,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bb1b-60aa-77af-6ba8" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -830,6 +905,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="35de-ccec-aa7c-571e" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -841,6 +917,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f4e-9379-01b9-8012" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -852,6 +929,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="25fc-5262-b57b-504c" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -863,6 +941,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd22-fb0d-2f2b-d47d" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -874,6 +953,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a719-0c26-eb2a-a1a8" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -885,6 +965,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b2b-1791-fff2-2a7f" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -896,6 +977,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="558c-aa93-02d5-71cd" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -907,6 +989,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="86e1-f96b-ac75-0901" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -918,6 +1001,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d80-f96f-3e3a-37e8" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -929,6 +1013,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f3fe-4da9-f6c8-f78b" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -940,6 +1025,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="38de-402c-219a-a530" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -951,6 +1037,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="185a-1e6e-8e33-6727" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -962,6 +1049,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -978,6 +1066,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4cb0-76d8-380f-d4a3" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -986,6 +1075,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffae-f734-831b-bdfd" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -994,6 +1084,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36ba-0094-fd70-ac0e" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1002,6 +1093,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="234b-af38-71cc-6ec4" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1010,6 +1102,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6b9b-0ed1-1097-f045" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1018,6 +1111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="763a-5285-de0a-8c9e" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1026,6 +1120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f842-2cac-9fc1-2772" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1034,6 +1129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95d7-a0fd-6dc3-2084" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1042,6 +1138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e8e6-7b3a-c94e-c93f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1050,6 +1147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e64-0bb0-61cf-6681" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1058,6 +1156,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee66-ea01-7ede-1b58" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1066,6 +1165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cfd7-4611-5c3b-527d" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1074,6 +1174,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6cba-be22-a307-5db2" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1082,6 +1183,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1097,6 +1199,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a019-fe19-0cda-8997" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1105,6 +1208,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3a7c-c0d6-079d-8817" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1113,6 +1217,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eebc-69f8-0ab0-fc6e" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1121,6 +1226,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db73-f0d4-671f-801b" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1129,6 +1235,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5b05-0230-8877-91bb" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1137,6 +1244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b132-9671-d791-32e5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1145,6 +1253,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1152,9 +1261,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8c52-ad3f-0992-e671" name="Orc Champion [75 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="fef6-9812-1714-e337" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
       </infoLinks>
@@ -1174,6 +1287,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="75.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="68b3-5fa5-8c3d-b213" name="Orc Champion in Medium Armour" hidden="false" collective="false" type="model">
@@ -1182,6 +1296,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="85.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1198,6 +1313,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f1fa-5d20-cc10-8388" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1206,6 +1322,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f32-937c-9a36-1b66" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1214,6 +1331,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96bf-e41f-1571-3914" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1222,6 +1340,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c74-d39f-d468-79a2" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -1230,6 +1349,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eeb3-30f3-1118-a4cd" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1238,6 +1358,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1253,6 +1374,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1269,6 +1391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f35-73d6-7425-97cf" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1277,6 +1400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1293,6 +1417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c4cc-b00f-db38-a08b" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1301,6 +1426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="71ac-bc83-2f82-7242" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1309,6 +1435,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1324,6 +1451,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1340,11 +1468,13 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b105-3767-8397-70af" name="Ferocious Charge" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1360,6 +1490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b9a7-5334-e57f-fb70" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1368,6 +1499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c06d-b05d-4c19-4d80" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1376,6 +1508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ba2e-6620-1079-e32b" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1384,6 +1517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2d80-7247-4690-206a" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1392,6 +1526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4f3e-acf8-9ceb-302b" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1400,6 +1535,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2ed7-c97a-254a-1bae" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1408,6 +1544,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1415,9 +1552,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ce3-888a-1952-2f6d" name="Orc Warriors [70 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="a936-7b02-7e17-ffac" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1440,6 +1581,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1456,6 +1598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8aa4-c2ce-3652-ed25" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1464,6 +1607,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="46ae-166e-ee54-0523" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1479,6 +1623,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1496,6 +1641,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="22.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f093-e625-e8c5-88e7" name="Orc Warrior" hidden="false" collective="false" type="model">
@@ -1508,6 +1654,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1515,9 +1662,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="776f-bb6e-cb3e-3f0d" name="Orc Archers [70 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="6bee-e46f-7111-ba2c" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
@@ -1537,6 +1688,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="300a-d660-da96-fa35" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -1552,6 +1704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1577,6 +1730,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e079-23a6-3b93-5149" name="Orc Archers" hidden="false" collective="false" type="model">
@@ -1589,6 +1743,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1596,6 +1751,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="688f-00f4-af7f-64f4" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1613,6 +1769,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1574-9d4a-84bc-576a" name="Orc Archers in Light Armour" hidden="false" collective="false" type="model">
@@ -1625,6 +1782,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1632,6 +1790,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1654,6 +1813,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1661,9 +1821,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="617f-5069-cbec-cae2" name="Trolls [105 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="07d2-3a27-f61a-dd55" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5dab-bfc8-0154-afb5" name="Regenerate" hidden="false" targetId="0a0c-ed4c-9647-4398" type="rule"/>
@@ -1685,6 +1849,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1692,9 +1857,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cecf-a6e9-be27-a87a" name="Orc Guard [70 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3b6a-cb8e-2401-f837" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1717,6 +1886,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1733,6 +1903,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8fd3-5df9-dc6c-5595" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1748,6 +1919,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1509-0615-1264-194b" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1756,6 +1928,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a2b4-9aad-7d80-33b6" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1764,6 +1937,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b67d-f6c9-ad8d-c689" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1772,6 +1946,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1797,6 +1972,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5ce9-04d5-4601-b1d8" name="Orc Guard in Light Armour" hidden="false" collective="false" type="model">
@@ -1809,6 +1985,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1816,6 +1993,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4973-5f15-bbfd-cff6" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1833,6 +2011,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2f50-2e85-7c16-62ca" name="Orc Guard in Medium Armour" hidden="false" collective="false" type="model">
@@ -1845,6 +2024,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1852,6 +2032,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1859,9 +2040,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9e88-a067-9011-aaec" name="Orc Boar Riders [85 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="9da8-ecfe-e655-c06b" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
         <infoLink id="d7d4-c5d7-31a6-9b80" name="Ferocious Charge" hidden="false" targetId="7ef8-77c6-28f8-c3e3" type="rule"/>
@@ -1883,6 +2068,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eca3-44f9-40d3-8f7c" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1891,6 +2077,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c7d6-9071-bac5-02a6" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1899,6 +2086,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1923,6 +2111,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="35.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="359d-8fb4-9855-0812" name="Orc Boar Rider in Light Armour" hidden="false" collective="false" type="model">
@@ -1935,6 +2124,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1942,6 +2132,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36e1-1c18-bf8b-8422" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1958,6 +2149,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="37.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8590-8aea-5f04-8508" name="Orc Boar Rider in Medium Armour" hidden="false" collective="false" type="model">
@@ -1970,6 +2162,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1977,6 +2170,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1984,9 +2178,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8409-5df8-64c6-07ee" name="Orc Boar Chariot [101 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="00e1-5920-a31f-3350" name="Boars" hidden="false" targetId="20f8-c95a-aeb0-4345" type="profile"/>
       </infoLinks>
@@ -2006,6 +2204,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="399b-ce13-7300-0217" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2014,6 +2213,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="122a-8a4e-f9e5-28a4" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2022,6 +2222,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2044,6 +2245,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2059,6 +2261,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2075,6 +2278,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2094,6 +2298,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="91.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2101,9 +2306,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3e4b-e953-ca97-44e9" name="Orc Stone Thrower [84 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5516-869c-892b-9c00" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2130,6 +2339,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2137,6 +2347,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="695b-6764-9cc9-7f88" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2155,6 +2366,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2162,6 +2374,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2178,6 +2391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53f6-0980-fa25-499e" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -2186,6 +2400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2202,6 +2417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ede-54a6-021e-8a4d" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2210,6 +2426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2217,9 +2434,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f424-904a-5733-500a" name="Orc Bolt Thrower [60 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9e53-2bf0-052e-5430" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2246,6 +2467,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2253,6 +2475,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d8e-cd2c-cb87-c973" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2271,6 +2494,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2278,6 +2502,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2294,6 +2519,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e204-5103-00e0-299e" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2302,6 +2528,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="51.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2318,6 +2545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="52a4-d766-b9d5-86ee" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2326,6 +2554,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2333,6 +2562,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Samurai.cat
+++ b/Samurai.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cd5c-e29b-080c-a69e" name="Samurai" revision="1" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cd5c-e29b-080c-a69e" name="Samurai" revision="2" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="c5fa-527f-fedb-136a" name="Daimyo [122 pts]" hidden="false" collective="false" targetId="7fb8-4fba-65cf-e467" type="selectionEntry"/>
     <entryLink id="b6d4-f3c3-3e38-5d65" name="Mounted Daimyo [148 pts]" hidden="false" collective="false" targetId="0548-5344-d38b-832f" type="selectionEntry"/>
@@ -23,6 +23,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="7fb8-4fba-65cf-e467" name="Daimyo [122 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="81f7-207f-45d2-8f06" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="5543-f077-9866-f35e" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -43,6 +46,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="82.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2ffa-dd56-9dbb-9292" name="Hatamoto in Medium Armour" hidden="false" collective="false" type="model">
@@ -56,6 +60,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -72,6 +77,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="64e5-82ab-15c9-27ca" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -80,6 +86,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -102,6 +109,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -118,6 +126,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a68a-d549-1683-96ad" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -126,6 +135,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -142,6 +152,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ed5-24ab-e29a-63d5" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -150,6 +161,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -165,6 +177,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b130-152b-8d88-540d" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -173,6 +186,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ca34-f5ca-7900-41ea" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -181,6 +195,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2bd8-54ae-2611-ea75" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -189,6 +204,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a24a-a202-55ae-c619" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -197,6 +213,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed19-e0da-7718-3fc9" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -205,6 +222,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4bfb-5f0f-9fd0-5f1a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -213,6 +231,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -220,9 +239,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0548-5344-d38b-832f" name="Mounted Daimyo [148 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="ce0b-f83a-5bf8-64ed" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="924a-1841-50b3-a873" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -244,6 +267,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="92.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e961-aed5-86ff-36f5" name="Hatamoto in Medium Armour" hidden="false" collective="false" type="model">
@@ -257,6 +281,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -273,6 +298,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6def-f70c-a5b5-ee79" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -288,6 +314,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -310,6 +337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -326,6 +354,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7569-fd57-75ec-1057" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -334,6 +363,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -350,6 +380,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3e19-a6dd-d4d1-d33b" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -358,6 +389,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -380,6 +412,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -395,6 +428,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36eb-5f78-dd0a-3d38" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -403,6 +437,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3f3-62cb-01c4-9da2" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -411,6 +446,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a742-298f-dc07-47f5" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -419,6 +455,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="899a-194d-daf5-9cf6" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -427,6 +464,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1d75-a72c-373c-49b0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -435,6 +473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c35-88d0-3079-48b5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -443,6 +482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -450,9 +490,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="546c-46ef-b4dc-cd2b" name="Onmyoji Diviner [55 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="c09c-2897-57eb-57ee" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
       </categoryLinks>
@@ -470,6 +514,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="55.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -493,6 +538,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -500,6 +546,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="485c-3d06-ba24-6414" name="Shikigami Spirits" hidden="false" collective="false" type="upgrade">
@@ -516,6 +563,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -523,6 +571,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -539,6 +588,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbc9-109a-63b1-8805" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -547,6 +597,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c53-f753-4142-a72d" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -555,6 +606,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -571,6 +623,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f36e-0a3f-20b4-5adf" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -579,6 +632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dbda-bc2e-bb8f-948e" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -587,6 +641,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ed0-9666-8d85-e1a7" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -595,6 +650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0fb-4705-18a8-5d02" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -603,6 +659,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4bae-cc91-9e78-524e" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -611,6 +668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3cbf-796e-d8b6-6b92" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -619,6 +677,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3991-b7a1-3bf5-60a3" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -627,6 +686,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e466-c37a-c655-3836" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -635,6 +695,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0340-ff1a-86f4-a7aa" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -643,6 +704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffec-13fb-3d10-039f" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -651,6 +713,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7904-d2de-a7ed-80ee" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -659,6 +722,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0404-a5d8-62e0-3ab3" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -667,6 +731,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="70ad-7356-732b-8f5f" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -675,6 +740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -690,6 +756,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f566-eb33-32e3-fcd7" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -701,6 +768,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="726f-992e-1660-87c6" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -712,6 +780,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="961c-d934-e42b-c125" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -723,6 +792,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7678-30bd-736b-fcf6" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -734,6 +804,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db5c-e878-75cb-b8ee" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -745,6 +816,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6d9a-53e9-7e75-6284" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -756,6 +828,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cb1a-d65c-e142-ce14" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -767,6 +840,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f91-ea51-050c-1dda" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -778,6 +852,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dae4-658a-9bf1-706d" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -789,6 +864,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53f1-4225-e57a-ab5a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -800,6 +876,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a33-d1c7-14d1-af87" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -811,6 +888,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f931-dbf8-e8af-2cd9" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -822,6 +900,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="97d6-71f6-b81f-b0af" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -833,6 +912,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -849,6 +929,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7eb0-c108-3e57-1ec2" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -857,6 +938,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -872,6 +954,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e60f-38e7-8369-36f1" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -880,6 +963,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5b58-9cd4-b8ba-2c2f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -888,6 +972,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b5a-399d-e4c2-c522" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -896,6 +981,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="afdc-15fd-a801-954d" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -904,6 +990,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6283-6f87-8311-69a0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -912,6 +999,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b631-45bc-a75d-564e" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -920,6 +1008,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -927,9 +1016,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1070-fe2d-2e93-c2c1" name="Shugyosha Samurai Hero [86 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="cf0a-92c4-c92a-a65b" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="8297-f0f5-d62d-f2d4" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -948,6 +1041,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -964,6 +1058,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1794-c6f7-8d3b-5b85" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -972,6 +1067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -987,6 +1083,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1002,6 +1099,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1017,6 +1115,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1033,6 +1132,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f748-b2f3-0192-a5f4" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1041,6 +1141,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1057,6 +1158,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8730-23f3-0948-d35a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1065,6 +1167,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3571-e988-f78c-7071" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1073,6 +1176,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1088,6 +1192,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="890d-e762-9ecd-296d" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1096,6 +1201,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ccd2-a7d0-ffaf-f26f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1104,6 +1210,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cc74-40e7-9373-085c" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1112,6 +1219,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7ec3-eb61-4594-cb71" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1120,6 +1228,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3ad5-9c4a-9d70-ec63" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1128,6 +1237,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="93ca-5329-5677-2b61" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1136,6 +1246,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1143,9 +1254,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e68b-8444-a4ef-bf6b" name="Mounted Shugyosha Samurai Hero [102 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="8086-28f6-7842-77f2" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="1a9b-1ba3-f600-58cd" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1164,6 +1279,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="102.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1180,6 +1296,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="351a-6a60-7bc6-ffbe" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -1188,6 +1305,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1203,6 +1321,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1218,6 +1337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1233,6 +1353,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1249,6 +1370,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="056d-0c5f-5cf7-a315" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1257,6 +1379,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1273,6 +1396,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7997-bc4e-2b6b-3b98" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1281,6 +1405,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b6c2-7b72-5ec5-9a1b" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1289,6 +1414,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1304,6 +1430,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1319,6 +1446,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="731c-dab1-a71e-7516" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1327,6 +1455,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fd43-90d6-290d-ef03" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1335,6 +1464,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd00-bf56-b285-7e37" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1343,6 +1473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e2f1-0bb4-f6ba-e5d9" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1351,6 +1482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="504f-a7ef-5bce-ac65" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1359,6 +1491,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f0fb-4ef8-9e23-4a9e" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1367,6 +1500,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1374,9 +1508,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7f2c-f65b-b0b8-36b8" name="Ninja Master" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="f7b7-b384-2f4a-c0ba" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="bc02-dba8-0fd3-6e7c" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1396,6 +1534,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="90.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1412,6 +1551,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9a30-5c5e-53b0-9668" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -1420,6 +1560,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d94-af99-2da8-28da" name="Nunchaku" hidden="false" collective="false" type="upgrade">
@@ -1428,6 +1569,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1444,6 +1586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4f49-8739-03a2-b998" name="Ranged Magic Weapons" hidden="false" collective="false" type="upgrade">
@@ -1459,6 +1602,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1174-8132-ab16-30dd" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1467,6 +1611,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="62bc-c789-1b37-44f1" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1475,6 +1620,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1482,6 +1628,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1497,6 +1644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1513,6 +1661,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e533-f642-dc71-3c81" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1521,6 +1670,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1537,6 +1687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a24a-d39a-3f20-6f2e" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1545,6 +1696,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c4b6-84b4-918e-7492" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1553,6 +1705,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1568,6 +1721,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa11-0d76-32f3-777c" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1576,6 +1730,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e346-c654-1d70-3b83" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1584,6 +1739,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ef29-42d1-7185-ffe4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1592,6 +1748,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5f66-cb62-5d3c-238f" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1600,6 +1757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9a3-5e0b-b50f-e92e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1608,6 +1766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0af7-48e5-9db1-2a42" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1616,6 +1775,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1623,9 +1783,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="31fd-5e25-2ed4-b763" name="Mounted Samurai [84 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="8f03-5707-d029-6d91" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
@@ -1644,6 +1808,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="901b-c09b-61cc-63ae" name="Samurai in Medium Armour, Riding Horse" hidden="false" collective="false" type="model">
@@ -1657,6 +1822,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1673,6 +1839,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b70d-c310-b4d5-5e49" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -1688,6 +1855,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ba89-49b3-040f-f5a3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1696,6 +1864,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1718,6 +1887,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1734,6 +1904,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18d2-3baf-34d4-a45a" name="Warhorses" hidden="false" collective="false" type="upgrade">
@@ -1749,6 +1920,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9c4b-c038-8f20-9791" name="Komainu Lion Dog" hidden="false" collective="false" type="upgrade">
@@ -1764,6 +1936,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1771,9 +1944,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bb3d-9040-9441-5630" name="Samurai [92 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="575f-53f8-d296-0f2e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1791,6 +1968,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8292-905e-eacf-3f11" name="Samurai" hidden="false" collective="false" type="model">
@@ -1803,6 +1981,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1819,6 +1998,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98ca-9f39-fa47-b428" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -1827,6 +2007,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="16ce-6494-6d8a-d749" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1835,6 +2016,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1857,6 +2039,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1864,9 +2047,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="22be-f604-b5ad-9a31" name="Ashigaru [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="c360-b3f6-4678-78c3" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1891,6 +2078,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4b63-9ddb-aa8d-d54f" name="Ashigaru leader in Light Armour" hidden="false" collective="false" type="model">
@@ -1904,6 +2092,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1911,6 +2100,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15ce-09d4-fe6e-5e5f" name="Ashigaru in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1928,6 +2118,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="aded-c528-a496-f3ee" name="Ashigaru in Medium Armour" hidden="false" collective="false" type="model">
@@ -1940,6 +2131,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1947,6 +2139,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1963,6 +2156,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd4b-f302-ca7e-afd5" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -1971,6 +2165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10a5-df23-edf6-f695" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1979,6 +2174,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3cc-ece7-a0af-5d25" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1987,6 +2183,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="baba-94bb-27e3-7cf4" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -2002,6 +2199,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2009,9 +2207,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="089f-9e45-d225-bd30" name="Archers [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="613e-0dc7-1357-e520" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
@@ -2039,6 +2241,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5e06-6932-d177-a733" name="Archer Leader" hidden="false" collective="false" type="model">
@@ -2052,6 +2255,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2059,6 +2263,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0d80-a67d-5432-4ae2" name="Archers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2076,6 +2281,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ab2d-cc42-d12c-26ca" name="Archers in Light Armour" hidden="false" collective="false" type="model">
@@ -2088,6 +2294,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2095,6 +2302,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2026-4800-3eda-e2bc" name="Archers in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2112,6 +2320,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f180-a9c8-efd8-7cb0" name="Archers in Medium Armour" hidden="false" collective="false" type="model">
@@ -2124,6 +2333,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2131,6 +2341,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2147,6 +2358,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f22b-285a-e598-51cb" name="Long Bows" hidden="false" collective="false" type="upgrade">
@@ -2162,6 +2374,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2169,9 +2382,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e5d4-364a-44f3-cf24" name="Bandits and Brigands [57 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="169b-796b-2654-f929" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -2189,6 +2406,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b4c-b0c8-dada-e057" name="Bandits" hidden="false" collective="false" type="model">
@@ -2201,6 +2419,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2217,6 +2436,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="905b-f9d4-3c69-ba64" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -2229,6 +2449,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2236,9 +2457,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b6af-603d-a7c3-a000" name="Tanigashima Men [82 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="4471-f073-f2b8-3b50" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="65c2-1d0c-f1f2-4588" name="Hand Gun" hidden="false" targetId="4d4a-8ee3-260b-037b" type="profile"/>
@@ -2268,6 +2493,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="45de-4e3a-f176-f907" name="Tanigashima Men" hidden="false" collective="false" type="model">
@@ -2280,6 +2506,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2287,6 +2514,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6851-781e-698a-2c66" name="Tanigashima Men in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2304,6 +2532,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3782-3b8f-fac6-8ad3" name="Tanigashima Men in Light Armour" hidden="false" collective="false" type="model">
@@ -2316,6 +2545,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2323,6 +2553,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d09e-f0ab-d4ea-f144" name="Tanigashima Men in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2340,6 +2571,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9ccb-08b0-1c51-6d9a" name="Tanigashima Men in Medium Armour" hidden="false" collective="false" type="model">
@@ -2352,6 +2584,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2359,6 +2592,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2381,6 +2615,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2388,9 +2623,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6e1d-4700-e35d-cfd5" name="Onna Bugeisha [62 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="6d9a-27a2-cefa-294e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -2416,6 +2655,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1c66-5212-72da-61ad" name="Onna Bugeisha" hidden="false" collective="false" type="model">
@@ -2428,6 +2668,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2435,6 +2676,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="65a9-2013-ba5b-0544" name="Onna Bugeisha in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2452,6 +2694,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a14f-9a1a-0d0f-0c48" name="Onna Bugeisha" hidden="false" collective="false" type="model">
@@ -2464,6 +2707,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2471,6 +2715,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ceb0-5d4c-cf72-146f" name="Onna Bugeisha in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2488,6 +2733,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b4a3-dd78-e08d-71e0" name="Onna Bugeisha" hidden="false" collective="false" type="model">
@@ -2500,6 +2746,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2507,6 +2754,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2529,6 +2777,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2545,6 +2794,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2dfe-9d67-dc0c-700c" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -2553,6 +2803,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a65-1140-9a0e-3211" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -2561,6 +2812,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2568,9 +2820,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1f70-b03f-149b-186e" name="Sohei Warrior Monks [132 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3836-3c5c-250b-1f2a" type="max"/>
       </constraints>
@@ -2600,6 +2856,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6242-6196-3635-234a" name="Monk" hidden="false" collective="false" type="model">
@@ -2612,6 +2869,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2619,6 +2877,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5182-3b4d-5c05-d639" name="Sohei Warrior Monks in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2637,6 +2896,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a395-4204-301a-e701" name="Monk in Light Armour" hidden="false" collective="false" type="model">
@@ -2649,6 +2909,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2656,6 +2917,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2678,6 +2940,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2694,6 +2957,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aecf-1199-89fa-8e81" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -2709,6 +2973,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2724,6 +2989,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2731,9 +2997,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e1ed-3a13-14a6-97e1" name="Ninja [205 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9380-11e5-3228-2fe8" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -2752,6 +3022,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="41.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2768,6 +3039,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b61d-53a5-92f9-e423" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -2776,6 +3048,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99ae-9cdf-f1d4-5c86" name="Nunchaku" hidden="false" collective="false" type="upgrade">
@@ -2784,6 +3057,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2796,6 +3070,7 @@
             <selectionEntry id="0256-06e0-6d14-9543" name="Dead Eye Shot" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2803,9 +3078,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7909-8c75-a592-8775" name="Oni Ogres [26 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="be43-3d07-54a4-cf38" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -2824,6 +3103,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="26.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2831,9 +3111,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1d8c-7e0b-a8ed-d1f8" name="Tengu Birdmen [144 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cd5-05ab-10ff-2d4d" type="max"/>
       </constraints>
@@ -2855,6 +3139,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="48.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2862,9 +3147,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e383-a41b-2f88-a302" name="Cannon [77 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="c2c5-5480-a49b-b56c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="c8e6-56fc-bd9c-e4a6" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2893,6 +3182,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2900,6 +3190,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b739-d5bd-1fee-5dfe" name="Cannon Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2916,6 +3207,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2923,6 +3215,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2939,6 +3232,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b326-65e6-9101-d76a" name="Large Cannon" hidden="false" collective="false" type="upgrade">
@@ -2947,6 +3241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="100.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2963,6 +3258,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="64d7-3af3-84c4-f050" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -2978,6 +3274,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2985,9 +3282,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1be0-ddf4-8aab-f6fb" name="Bolt Thrower [69 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="7f5c-a1d5-0ec7-97d8" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="010a-8f61-8e05-8247" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -3016,6 +3317,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3023,6 +3325,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d6ee-ab3a-fc3b-61bb" name="Bolt Thrower Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -3039,6 +3342,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3046,6 +3350,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3062,6 +3367,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="376f-b959-1f8b-048c" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -3070,6 +3376,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3086,6 +3393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bfb3-da1d-bfeb-29f8" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -3101,6 +3409,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3108,6 +3417,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -3420,7 +3730,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="6dcf-b813-589c-27e8" name="Mixed Arms" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="6dcf-b813-589c-27e8" name="Mixed Arms" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR</characteristic>

--- a/Snakemen.cat
+++ b/Snakemen.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="152d-3173-80b2-a764" name="Snakemen" revision="1" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="152d-3173-80b2-a764" name="Snakemen" revision="2" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="1a78-4648-bf1b-ebd0" name="Snakeman Serpent Lord [103 pts]" hidden="false" collective="false" targetId="4f93-772c-1a68-d127" type="selectionEntry"/>
     <entryLink id="8258-9325-b4ad-7d2d" name="Snakeman High-Priest of Hissta [60 pts]" hidden="false" collective="false" targetId="2019-dbf1-8aa9-364d" type="selectionEntry"/>
@@ -17,6 +17,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4f93-772c-1a68-d127" name="Snakeman Serpent Lord [103 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="a580-b659-c3f5-2efc" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="1fb4-7485-73d9-6a93" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -44,6 +47,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="75.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="178d-8fdc-c4ff-d7e8" name="Snakeman Bodyguard" hidden="false" collective="false" type="model">
@@ -56,6 +60,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -63,6 +68,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="276b-b7ff-6475-baf0" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -81,6 +87,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="85.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ff3f-f029-c46b-44b3" name="Snakeman Bodyguard" hidden="false" collective="false" type="model">
@@ -93,6 +100,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -100,6 +108,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -116,6 +125,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3440-1ece-770f-f46a" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -124,6 +134,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -139,6 +150,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -155,6 +167,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3f9e-4ed1-6030-198a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -163,6 +176,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -179,6 +193,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e720-6c1c-cb62-0a35" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -187,6 +202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4493-4cfc-3e9d-e069" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -195,6 +211,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="92fc-720f-6f36-8b09" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -203,6 +220,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -218,6 +236,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dbf8-6f35-ec0a-f0f2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -226,6 +245,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b997-514e-55d0-473d" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -234,6 +254,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e58f-98c6-81e7-f284" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -242,6 +263,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="835c-7550-3ba8-1a6e" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -250,6 +272,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ea1-4172-fa68-e1a0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -258,6 +281,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="678c-924d-94f7-734a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -266,6 +290,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -273,9 +298,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2019-dbf1-8aa9-364d" name="Snakeman High-Priest of Hissta [60 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5a11-bfe5-42f8-4422" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
         <categoryLink id="198e-9bd8-a312-1917" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -294,6 +323,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -310,6 +340,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff02-d2fd-50db-de94" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -318,6 +349,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f732-8518-f069-ef11" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -326,6 +358,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -342,6 +375,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c80a-2120-1dc3-2955" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -350,6 +384,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2e8d-b3c7-f838-1292" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -358,6 +393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da07-4691-43f4-2f15" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -366,6 +402,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a42e-c7b9-18db-3418" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -374,6 +411,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c78-7df7-e7d6-7d77" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -382,6 +420,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6102-3ce3-1747-d9aa" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -390,6 +429,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9394-e443-a958-921f" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -398,6 +438,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2a14-cfa0-fc14-b278" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -406,6 +447,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4b00-73b0-0672-83aa" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -414,6 +456,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9fcd-c770-f0b8-2a13" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -422,6 +465,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e842-3ef1-89e9-57de" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -430,6 +474,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a32c-0e35-e71f-0f74" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -438,6 +483,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4201-22ae-6d01-83bc" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -446,6 +492,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -461,6 +508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d557-7b9a-4c07-ac2b" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -472,6 +520,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de1d-ea81-2ccf-8f80" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -483,6 +532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0107-16ec-14c4-a655" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -494,6 +544,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e9e1-4630-3953-2e34" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -505,6 +556,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4041-8992-74f2-534b" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -516,6 +568,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c06-bcda-2b07-05b5" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -527,6 +580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c72d-5f19-dc88-9797" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -538,6 +592,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8be2-8b0a-bbe7-5721" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -549,6 +604,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d5c6-dc8f-e3e2-7567" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -560,6 +616,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="999c-ce3f-be75-176a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -571,6 +628,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1243-d77e-44a0-dd7a" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -582,6 +640,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7458-06ea-264b-bf2c" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -593,6 +652,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c657-e0b2-708f-1b10" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -604,6 +664,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -620,6 +681,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6eb-82fb-174a-6419" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -628,6 +690,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -651,6 +714,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="209a-458e-040d-659d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -666,6 +730,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed10-d05c-b2c3-e68c" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -674,6 +739,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -696,6 +762,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -703,6 +770,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de00-ff55-111a-81a3" name="Spirits" hidden="false" collective="false" type="upgrade">
@@ -719,6 +787,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -726,6 +795,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -741,6 +811,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -756,6 +827,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5d4-7702-9a86-ace7" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -764,6 +836,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c6fb-545f-a304-f241" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -772,6 +845,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e25-fd2b-1036-15d9" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -780,6 +854,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="084c-40d5-56d9-7141" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -788,6 +863,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51e1-d088-8a78-fc02" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -796,6 +872,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6cc6-3b48-68bf-a9a8" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -804,6 +881,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -811,9 +889,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1a5e-d33f-9652-297f" name="Snakeman Cosmic Star Serpent Hero [86 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="e42f-dd29-ed29-5c70" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
         <infoLink id="653a-3490-5b89-dbc4" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
@@ -836,6 +918,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="20f3-a7f9-64ff-ac91" name="Snakeman Hero in Light Armour" hidden="false" collective="false" type="model">
@@ -844,6 +927,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="96.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04d1-ac6a-4342-2533" name="Snakeman Hero in Medium Armour" hidden="false" collective="false" type="model">
@@ -852,6 +936,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="106.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -868,6 +953,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2067-0ddd-d02b-658d" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -876,6 +962,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="41fe-c8d8-c4b9-5d04" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -884,6 +971,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b640-2656-7500-f5ef" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -892,6 +980,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -908,6 +997,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="752c-04a9-3365-da57" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -916,6 +1006,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d36b-a862-349e-1bc7" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -924,6 +1015,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -940,6 +1032,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de95-7a8b-59e1-0927" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -948,6 +1041,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -963,6 +1057,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -978,6 +1073,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -993,6 +1089,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="63b8-b32d-64ea-9207" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1001,6 +1098,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="095e-2101-1382-5415" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1009,6 +1107,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e94e-d081-1208-bc1f" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1017,6 +1116,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f564-8f16-2fe3-8460" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1025,6 +1125,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="26fa-ce47-e67b-e29e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1033,6 +1134,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d312-06a5-e4e3-7529" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1041,6 +1143,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1048,9 +1151,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7cba-b245-d058-46af" name="Snakeman Python Guard [82 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="a254-b10e-25ef-b72f" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1076,6 +1183,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9e27-bffa-e77b-4cf9" name="Snakeman Python Guard" hidden="false" collective="false" type="model">
@@ -1088,6 +1196,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1095,6 +1204,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a112-5b56-ed27-fb46" name="Python Guard in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1112,6 +1222,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="19de-dc65-2f75-3205" name="Snakeman Python Guard" hidden="false" collective="false" type="model">
@@ -1124,6 +1235,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1131,6 +1243,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1147,6 +1260,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c34b-5aaf-e17f-daab" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1155,6 +1269,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cecd-dacc-06fa-d32e" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1163,6 +1278,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6756-bc6d-c1b8-3435" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1171,6 +1287,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1193,6 +1310,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1200,9 +1318,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="37b6-f4e6-0e5d-6d14" name="Snakeman Warriors [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="e4d3-1c86-8538-a954" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1228,6 +1350,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d673-810d-9059-6534" name="Snakeman Warriors" hidden="false" collective="false" type="model">
@@ -1240,6 +1363,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1247,6 +1371,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3b7a-02b0-e81c-58ba" name="Snakeman Warriors in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1264,6 +1389,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="510f-aef8-abdb-3249" name="Snakeman Warriors in Light Armour" hidden="false" collective="false" type="model">
@@ -1276,6 +1402,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1283,6 +1410,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1299,6 +1427,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f120-e673-346b-6ff2" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1307,6 +1436,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da2d-0b45-d842-a71a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1315,6 +1445,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="16e9-94a4-fd6b-dcda" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1323,6 +1454,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1330,9 +1462,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9033-ab9b-3a31-06fd" name="Snakeman Viper Warriors [77 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="1d47-a883-db09-12dd" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1358,6 +1494,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2028-5d67-0165-2478" name="Snakeman Warriors" hidden="false" collective="false" type="model">
@@ -1370,6 +1507,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1377,6 +1515,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1400,6 +1539,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="369d-0781-3f1e-ba04" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1415,6 +1555,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a40e-4e95-5e63-f805" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -1423,6 +1564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1438,6 +1580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1454,6 +1597,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1461,9 +1605,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="995b-88e6-92aa-8220" name="Snakeman Cobra Guard [87 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbc2-6757-f7bf-22f1" type="max"/>
       </constraints>
@@ -1492,6 +1640,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ba64-6d55-8979-525d" name="Snakemen Cobra Guard" hidden="false" collective="false" type="model">
@@ -1504,6 +1653,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1511,6 +1661,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1534,6 +1685,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a002-9b39-159f-50f5" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1549,6 +1701,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9692-2f72-d29c-cf6e" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -1557,6 +1710,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1572,6 +1726,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1588,6 +1743,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1610,6 +1766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1617,9 +1774,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="00aa-31c0-56fc-f219" name="Hemata Elder Guardian [41 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9973-af89-79b8-5c63" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -1639,6 +1800,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="41.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1654,6 +1816,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1669,6 +1832,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1676,9 +1840,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="73c2-ab60-7aef-87f4" name="Gorgon Elder Serpent [62 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b28-0983-05bd-82b7" type="max"/>
       </constraints>
@@ -1700,6 +1868,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1712,6 +1881,7 @@
             <selectionEntry id="8ba4-8e74-e61f-b0bd" name="Baleful Glare (can shoot bow or use glare, but not both at same time)" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1727,6 +1897,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1743,6 +1914,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4103-e8fc-92b3-f39a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1751,6 +1923,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1758,9 +1931,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c1d8-f242-88b4-7ce4" name="Saurian Slithering Beast Pack [94 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="50fc-7522-b9fa-d20a" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
         <categoryLink id="8c69-aab2-d0b2-cd51" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1786,11 +1963,12 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="02b2-6eea-ff2c-760e" name="Snakeman Pack Master" hidden="false" targetId="ae15-5d71-d1f1-6cd9" type="profile"/>
-                        <infoLink id="1fcc-44a6-6d4d-f84e" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                        <infoLink id="1fcc-44a6-6d4d-f84e" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
                         <infoLink id="5f7f-c1a9-7945-0d45" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6deb-a7da-9c79-f955" name="Snakeman Pack Master in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1799,11 +1977,12 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="efb0-69c7-e77b-4c89" name="Snakeman Pack Master in Light Armour" hidden="false" targetId="5cbe-12a3-d570-ea10" type="profile"/>
-                        <infoLink id="df04-7bc7-9a43-7eb5" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                        <infoLink id="df04-7bc7-9a43-7eb5" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
                         <infoLink id="69b6-c1f9-b1af-7f78" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1811,6 +1990,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e6df-3af4-1018-bcfa" name="Saurian Beasts" hidden="false" collective="false" type="upgrade">
@@ -1828,11 +2008,12 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="e116-10ff-1a56-7c80" name="Saurian Beast" hidden="false" targetId="0ee0-9140-215b-34fb" type="profile"/>
-                        <infoLink id="ed34-a10e-73d9-89fa" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                        <infoLink id="ed34-a10e-73d9-89fa" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
                         <infoLink id="764e-94dd-955a-4598" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1840,6 +2021,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1856,6 +2038,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="161c-4036-7a6c-ee2b" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1864,6 +2047,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="159c-eb2e-7496-a9e3" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1872,6 +2056,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1884,6 +2069,7 @@
             <selectionEntry id="8e27-5d6a-b89d-d9a2" name="Packmaster Bow Upgrade" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1906,6 +2092,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df82-c8e4-244f-8bde" name="Give Saurian Beasts Venomous Attacks" hidden="false" collective="false" type="upgrade">
@@ -1914,6 +2101,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1921,9 +2109,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="19f9-b7db-3799-e42a" name="Pterosaurs [129 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8756-422d-cf47-3a13" type="max"/>
       </constraints>
@@ -1946,6 +2138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="43.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1953,9 +2146,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3cb6-522d-f175-f84e" name="Tyrannosaur/Sail Back Saurian/Giant Horned Saurian" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0100-f7ee-ab55-4691" type="max"/>
       </constraints>
@@ -1982,6 +2179,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="188.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6b28-7ddf-fb35-978d" name="Sail Back Saurian" hidden="false" collective="false" type="model">
@@ -1991,6 +2189,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="126.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="913b-a478-a055-62f0" name="Giant Horned Saurian" hidden="false" collective="false" type="model">
@@ -2000,6 +2199,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="122.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2007,9 +2207,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c917-12a1-c769-10e1" name="Raptors [93 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="a1e8-455d-2f92-b62f" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -2029,6 +2233,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="31.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2036,6 +2241,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Undead.cat
+++ b/Undead.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e5b3-ac3f-4947-9875" name="Undead" revision="2" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e5b3-ac3f-4947-9875" name="Undead" revision="3" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="be7a-2982-bed2-d5b1" name="Necromancer" hidden="false" collective="false" targetId="837f-5310-663b-e80c" type="selectionEntry"/>
     <entryLink id="7019-c706-1279-e7a8" name="Liche" hidden="false" collective="false" targetId="c169-7c00-8d5e-beb4" type="selectionEntry"/>
@@ -21,6 +21,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="837f-5310-663b-e80c" name="Necromancer [81 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="810c-be4f-9e3b-7273" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="11b5-c350-01ea-967a" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -41,6 +44,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -57,6 +61,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="21a1-3820-5a30-d96e" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -65,6 +70,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bdf8-377f-9a77-e3ef" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -73,6 +79,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -89,6 +96,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -105,6 +113,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7770-041b-eeaf-b262" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -113,6 +122,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="428d-2d79-ff02-79a7" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -121,6 +131,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -137,6 +148,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f7a-f18c-65dc-3575" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -145,6 +157,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e08-334d-6302-a693" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -153,6 +166,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -169,6 +183,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="23.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -193,6 +208,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -209,6 +225,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="44d9-481c-dd4d-84ad" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -217,6 +234,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="4125-5792-c0d2-d540" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -225,6 +243,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="fd63-4726-ffaa-406a" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -240,6 +259,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -249,6 +269,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="915f-a17d-ea5f-f21c" name="Bodyguards in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -266,6 +287,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -282,6 +304,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="b902-934a-9abf-b4d8" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -290,6 +313,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="6ce5-a5b6-e630-a54e" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -298,6 +322,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="0003-aa2c-a842-4ee6" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -313,6 +338,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -322,6 +348,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -338,6 +365,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2672-6938-6681-fdd9" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -346,6 +374,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1267-e860-d6b3-566d" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -354,6 +383,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ff9-0f62-c458-5e25" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -362,6 +392,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87ef-2150-f4dd-4be0" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -370,6 +401,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f29-518f-7ca5-3bfd" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -378,6 +410,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7380-3ada-e966-d906" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -386,6 +419,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d14-f52c-3401-9d3a" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -394,6 +428,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ca44-49ee-2831-c65a" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -402,6 +437,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="40b8-64e0-7ef6-264f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -410,6 +446,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2a33-e79b-fea5-f483" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -418,6 +455,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d822-74a3-91ec-a505" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -426,6 +464,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d511-9e64-6d4a-93dc" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -434,6 +473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df89-a591-08b8-040e" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -442,6 +482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -457,6 +498,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa2b-8d0c-58ad-8b89" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -468,6 +510,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b8c7-11b0-1b25-4802" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -479,6 +522,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="165e-eb4d-02fd-0599" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -490,6 +534,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="19cf-6597-7124-06bc" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -501,6 +546,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d7a6-d5dc-51a4-b991" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -512,6 +558,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3436-5ef5-f81a-631e" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -523,6 +570,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="473f-e90f-77c4-9ea0" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -534,6 +582,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90df-d6ce-68a6-8bef" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -545,6 +594,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fde8-15e4-7fae-8f20" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -556,6 +606,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58c7-7c78-400f-eb1e" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -567,6 +618,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6a1b-8082-47f5-13ca" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -578,6 +630,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbcf-7ee5-4f1a-3a16" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -589,6 +642,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c822-3fb3-2260-9009" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -600,6 +654,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -615,6 +670,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5c3e-1ece-17fa-e976" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -623,6 +679,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7cee-ce4a-451a-d58d" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -631,6 +688,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="615d-f52b-782d-4986" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -639,6 +697,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="06c0-d7cc-0b6b-d154" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -647,6 +706,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a345-6b9c-2ea4-d077" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -655,6 +715,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2e80-0d7b-9d5f-a171" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -663,6 +724,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -670,9 +732,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c169-7c00-8d5e-beb4" name="Liche [95 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="43d0-ae8a-ca79-df32" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="efe9-7ace-9588-c8c6" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -693,6 +759,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -717,6 +784,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -733,6 +801,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="3bd1-a6f3-486d-a92c" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -741,6 +810,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="ee3e-3174-42dd-b2a4" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -749,6 +819,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="822a-8df4-d037-8dd4" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -764,6 +835,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -773,6 +845,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9056-fc54-a741-306f" name="Bodyguards in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -790,6 +863,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -806,6 +880,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="03b6-423f-4623-97ce" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -814,6 +889,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="c22a-47ad-2735-f312" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -822,6 +898,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="dbd5-2a45-e7c6-e166" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -837,6 +914,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -846,6 +924,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -862,6 +941,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e84-f420-70f9-b752" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -870,6 +950,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d021-e873-06b2-5f28" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -878,6 +959,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -894,6 +976,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5705-70d2-5c2c-8d9e" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -902,6 +985,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d12a-9fd4-b6fc-6cf5" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -910,6 +994,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -926,6 +1011,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="40ce-415d-d751-724c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -934,6 +1020,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62c7-b8e9-f82d-79bc" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -942,6 +1029,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -958,6 +1046,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="23.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -974,6 +1063,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a0cb-910b-8b5f-f70c" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -982,6 +1072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b769-ec2c-3cc6-445f" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -990,6 +1081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51ea-3891-9e4a-a1b7" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -998,6 +1090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e32-007e-a5e4-6164" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1006,6 +1099,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e90-9c34-2343-bb60" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1014,6 +1108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66a4-af77-1228-8748" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1022,6 +1117,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3401-1960-5a55-d7ed" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1030,6 +1126,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="663f-654c-c50c-6d69" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1038,6 +1135,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e6f-1ae8-2e72-f3c1" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1046,6 +1144,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da26-42a5-bf43-ed81" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1054,6 +1153,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f286-1325-49a7-fad4" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1062,6 +1162,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f40a-036a-ba28-e70b" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1070,6 +1171,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="07f3-6cc1-ebff-879c" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1078,6 +1180,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1093,6 +1196,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ec64-758b-ce37-86be" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1104,6 +1208,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5ba-7573-1d2d-c482" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1115,6 +1220,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5826-6978-560d-ab1e" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1126,6 +1232,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a539-af09-2bcf-a17e" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1137,6 +1244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0253-a01c-eafa-2855" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1148,6 +1256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fdb3-9cd6-52ae-1533" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1159,6 +1268,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fcfc-0924-c21a-a3e2" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1170,6 +1280,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e503-70a6-b910-76ed" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1181,6 +1292,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62ef-4e27-ecb7-5b9e" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1192,6 +1304,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c119-b2cb-7016-7dff" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1203,6 +1316,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="245c-b517-cc20-ea7d" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1214,6 +1328,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6315-5e42-87a5-1b47" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1225,6 +1340,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8c43-ee24-062b-9348" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1236,6 +1352,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1251,6 +1368,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="269d-3044-59bb-5285" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1259,6 +1377,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c9b-746c-44e6-edb5" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1267,6 +1386,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fa64-df9e-f330-df4f" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1275,6 +1395,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7485-211d-b4e4-7002" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1283,6 +1404,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96db-2703-a03d-57c4" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1291,6 +1413,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f2b-4c97-12bf-3479" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1299,6 +1422,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1306,9 +1430,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3825-19e7-b8da-c98f" name="Liche Riding Chariot [182 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="59b4-c112-71af-79cc" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="23e0-5b06-a1dc-0624" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
@@ -1329,6 +1457,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="177.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1346,6 +1475,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1361,6 +1491,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1377,6 +1508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b6ec-e914-ea35-b93e" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -1385,6 +1517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ab9c-40b3-5968-30cc" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -1393,6 +1526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1409,6 +1543,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="954f-f156-324e-fb39" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1417,6 +1552,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8abb-6a46-16f1-b26c" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1425,6 +1561,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1441,6 +1578,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73f8-6dbf-634d-4810" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1449,6 +1587,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd24-e36d-5122-cf04" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1457,6 +1596,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1473,6 +1613,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15a8-6253-1e1a-a0ac" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1481,6 +1622,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a092-6880-ccf9-ad5d" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1489,6 +1631,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="196f-1557-663e-e644" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1504,6 +1647,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1519,6 +1663,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="12b2-7618-4408-2332" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1530,6 +1675,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a63-c1c9-9af0-5195" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1541,6 +1687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bad1-f317-fd04-feaa" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1552,6 +1699,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15a9-bee6-b368-0aec" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1563,6 +1711,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cb2a-bf8b-90f8-26b9" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1574,6 +1723,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4b24-70d4-1dc9-803b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1585,6 +1735,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4e6d-637e-f0a0-fb2a" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1596,6 +1747,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="acbc-f6e4-116a-f2b7" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1607,6 +1759,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aed7-cfcb-c124-7c37" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1618,6 +1771,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="56dd-ce0a-2014-166a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1629,6 +1783,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="42ae-c68c-aeca-1bc3" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1640,6 +1795,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="953c-13f0-a956-0220" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1651,6 +1807,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="352a-b437-62c2-de0b" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1662,6 +1819,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1678,6 +1836,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d69-3d34-46b3-0b54" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1686,6 +1845,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2458-10d8-0e07-cc8f" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1694,6 +1854,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7b27-ff5e-3b0b-5173" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1702,6 +1863,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66e8-bf64-bad5-60f9" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1710,6 +1872,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="975e-1b78-5729-8b43" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1718,6 +1881,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac25-f080-2f4a-58b1" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1726,6 +1890,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="463a-f2a4-e416-734f" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1734,6 +1899,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4935-2ec0-67f8-cb7f" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1742,6 +1908,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="07d0-516a-15ac-1e25" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1750,6 +1917,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3781-f80c-6ae5-0fca" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1758,6 +1926,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f42-b3af-8638-4571" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1766,6 +1935,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a5d9-f06a-51fe-811b" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1774,6 +1944,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9c27-a795-17f7-cd2d" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1782,6 +1953,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1797,6 +1969,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4b8e-ae24-28a3-c2bd" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1805,6 +1978,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0df8-3fd1-3e60-3867" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1813,6 +1987,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b43-77fb-18cb-2e7b" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1821,6 +1996,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7c07-682c-a1c0-15bd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1829,6 +2005,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b680-7489-cd91-2c6d" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1837,6 +2014,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91ce-b4eb-de7b-3621" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1845,6 +2023,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1866,6 +2045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="177.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1873,9 +2053,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5dec-1724-fd5c-0163" name="Wraith (on foot) [154 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="7eb9-7a67-22f6-e9c8" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="ec66-5b83-d1fe-54b8" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1898,6 +2082,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="154.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1914,6 +2099,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1867-f2f8-a378-f738" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -1922,6 +2108,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="25.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="35a1-8e76-7687-6192" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -1930,6 +2117,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="50.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -1948,6 +2136,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd84-c64d-7d66-5108" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1956,6 +2145,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1972,6 +2162,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="82af-0103-caca-8956" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1980,6 +2171,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1996,6 +2188,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="23.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2012,6 +2205,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b18-4c6e-39eb-ae3c" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2020,6 +2214,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fb45-9141-fb7f-6de2" name="Mace" hidden="false" collective="false" type="upgrade">
@@ -2028,6 +2223,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2052,6 +2248,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2068,6 +2265,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="e0c5-589a-65b3-c7a1" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -2076,6 +2274,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="fe41-49d8-036a-fef1" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2084,6 +2283,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="1ff8-9fb2-cf10-e59c" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -2099,6 +2299,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -2108,6 +2309,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a029-d7c0-5c3c-7e49" name="Bodyguards in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2125,6 +2327,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2141,6 +2344,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="ed41-fdea-2349-5f0d" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -2149,6 +2353,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="3526-9de4-f0e1-4001" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2157,6 +2362,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="9dc3-0f00-5678-3cc7" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -2172,6 +2378,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -2181,6 +2388,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2196,6 +2404,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9932-004e-20c5-92f2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2204,6 +2413,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7742-26ba-a4eb-e23d" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2212,6 +2422,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="810b-d7cf-aa42-75f4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2220,6 +2431,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="272b-3da8-1c84-dc3d" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2228,6 +2440,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98f6-2089-f743-6263" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2236,6 +2449,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2cb7-af31-f2bb-7715" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2244,6 +2458,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2260,6 +2475,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="74b3-f4e2-03a0-6ac7" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2268,6 +2484,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4be2-7c60-d34a-5691" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2276,6 +2493,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="33d0-035d-3761-a0d6" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2284,6 +2502,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cef6-2e74-cb9a-ca10" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2292,6 +2511,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="295d-e544-e761-a369" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2300,6 +2520,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e241-6fe5-02b8-2d36" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2308,6 +2529,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="39e4-8b30-8672-c1d1" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2316,6 +2538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac9a-6910-c0cf-b8da" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2324,6 +2547,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b54-386c-00ed-5f30" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2332,6 +2556,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="813c-fe61-0c92-984b" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2340,6 +2565,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd28-40d5-3d2f-bd9d" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2348,6 +2574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44e7-40a3-9244-5940" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2356,6 +2583,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0fc6-47e1-f063-2916" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2364,6 +2592,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2379,6 +2608,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="37ef-9217-1bb9-3b06" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2390,6 +2620,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbec-fd38-2827-d778" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2401,6 +2632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd99-23b5-cc31-11f1" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2412,6 +2644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e097-9d0e-0063-6cff" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2423,6 +2656,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2275-148a-6181-4329" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2434,6 +2668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a41d-827c-bbe2-a921" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2445,6 +2680,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f1c-2fc7-0dc8-fd65" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2456,6 +2692,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d886-9571-ddbb-f4e0" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2467,6 +2704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c1dd-ba4a-4cf5-0f3f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2478,6 +2716,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="267f-1e40-27a7-8211" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2489,6 +2728,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f32-d244-ed20-55b3" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2500,6 +2740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8696-1ce2-cb64-ccdc" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2511,6 +2752,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="05b6-1b13-5c1c-5561" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2522,6 +2764,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2529,9 +2772,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d07b-3258-0b1e-a537" name="Wraith Riding Helhorse [189 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="45bd-b984-d92c-dbb3" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="91e7-e372-1fd0-d557" name="Mounted Unit" hidden="false" targetId="mounted unit" primary="false"/>
@@ -2553,6 +2800,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="166.0"/>
+            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2569,6 +2817,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b1a9-0a78-8d14-9c35" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -2577,6 +2826,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6b25-b0cc-9f5c-6afd" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -2585,6 +2835,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2601,6 +2852,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ca37-4a87-3491-4d41" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -2609,6 +2861,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2625,6 +2878,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce29-d194-ab26-81b2" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -2633,6 +2887,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2649,6 +2904,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="28f3-c794-8eed-7b25" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2657,6 +2913,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d4d-cb0b-995a-0585" name="Mace" hidden="false" collective="false" type="upgrade">
@@ -2665,6 +2922,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2682,6 +2940,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="29.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2697,6 +2956,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1175-e72d-0fe5-c739" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2705,6 +2965,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7477-6219-c9ef-d14d" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2713,6 +2974,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f40-0913-b262-33fa" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2721,6 +2983,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1d7a-d068-3c62-6daa" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2729,6 +2992,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebef-8123-e201-8174" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2737,6 +3001,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b68-3e1e-552e-3481" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2745,6 +3010,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2761,6 +3027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8a0d-7802-d789-112a" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2769,6 +3036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1994-dae3-7b91-c95a" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2777,6 +3045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c9de-e98f-d096-2f5b" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2785,6 +3054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="47fd-00e3-00bc-3754" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2793,6 +3063,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4938-07d7-b281-fbd3" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2801,6 +3072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6775-1810-75ff-893a" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2809,6 +3081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="841d-cc91-6f92-4626" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2817,6 +3090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="31fb-1fb0-0f50-ebd7" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2825,6 +3099,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89a2-03bd-5a17-adc6" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2833,6 +3108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d75a-2bef-6624-23d3" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2841,6 +3117,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c4b7-cd81-3274-c6c8" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2849,6 +3126,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fb42-7b1d-ed60-531b" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2857,6 +3135,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0e1-9ef7-143e-3226" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2865,6 +3144,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2880,6 +3160,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1790-a22e-e5c0-4aac" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2891,6 +3172,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a240-a0b6-b709-9bc0" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2902,6 +3184,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6a3e-469b-ef3a-3dd5" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2913,6 +3196,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02af-95d7-3e51-e2e1" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2924,6 +3208,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88b7-556d-7a92-b490" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2935,6 +3220,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c2e3-a6bd-f1c1-fd4d" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2946,6 +3232,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dfe8-bbe9-9906-9766" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2957,6 +3244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8200-f338-49bd-c399" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2968,6 +3256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd79-c598-2391-ca60" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2979,6 +3268,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d2c-a06b-fa6e-a2dd" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2990,6 +3280,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="97f1-9c77-f48c-91bb" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -3001,6 +3292,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eb9e-c9f2-d160-ffa8" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -3012,6 +3304,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee95-8402-c091-8ced" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -3023,6 +3316,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3030,9 +3324,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4e74-e623-34ea-f67d" name="Undead Champion [81 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bac-4242-05e0-cfdf" type="max"/>
       </constraints>
@@ -3057,6 +3355,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3866-bc5f-d64e-d32b" name="Undead Champion in Heavy Armour" hidden="false" collective="false" type="model">
@@ -3066,6 +3365,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="84.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3082,6 +3382,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="43b0-f1f8-152d-d4e9" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -3090,6 +3391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a1a6-096c-4595-95a8" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -3098,6 +3400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7168-61e9-69ea-bf4c" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -3106,6 +3409,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="03a0-3858-f9b7-4f56" name="Warhammer" hidden="false" collective="false" type="upgrade">
@@ -3114,6 +3418,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3130,6 +3435,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="77cd-e38b-2d7f-aeb0" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -3138,6 +3444,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="091a-d947-ee93-7746" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -3146,6 +3453,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3162,6 +3470,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2fab-807b-d2fd-01dd" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -3170,6 +3479,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3186,6 +3496,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a857-faab-d553-6816" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -3194,6 +3505,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3209,6 +3521,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2434-44ec-aea7-356b" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -3217,6 +3530,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0703-83b4-924b-5409" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -3225,6 +3539,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c932-7843-6904-8f85" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -3233,6 +3548,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="133f-05ef-d747-96bd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -3241,6 +3557,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fb04-3e53-ecf0-9a00" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -3249,6 +3566,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="edc2-0f64-7e7a-78a4" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -3257,6 +3575,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3264,9 +3583,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b40f-b67e-0346-aea0" name="Skeleton Guard [59 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c9f-1b12-88f5-5405" type="max"/>
       </constraints>
@@ -3297,6 +3620,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="bc98-5f32-1d99-c47b" name="Skeleton Guard Leader" hidden="false" collective="false" type="model">
@@ -3310,6 +3634,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3317,6 +3642,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b094-e9e9-7a19-a405" name="Skeleton Guard in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -3333,6 +3659,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9502-18f2-04ca-e650" name="Skeleton Guard Leader" hidden="false" collective="false" type="model">
@@ -3346,6 +3673,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3353,6 +3681,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3369,6 +3698,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2443-fc4f-e88f-c5e2" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -3384,6 +3714,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a7f6-bc4e-bf28-e0dd" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -3392,6 +3723,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd66-2887-ff72-9a1b" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -3400,6 +3732,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cca2-8ca9-82c7-1ed0" name="Massive Maces" hidden="false" collective="false" type="upgrade">
@@ -3408,6 +3741,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="364e-6313-c8f0-a0b0" name="Warhammer" hidden="false" collective="false" type="upgrade">
@@ -3416,6 +3750,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1220-d1b7-09d7-96f5" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -3424,6 +3759,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3440,6 +3776,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7199-fd53-0016-65aa" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -3455,6 +3792,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3462,9 +3800,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="165e-1098-6932-7727" name="Skeleton Warriors [57 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="71f4-6078-6130-8c07" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>
@@ -3485,6 +3827,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8592-067a-f084-d6b1" name="Skeleton Warrior" hidden="false" collective="false" type="model">
@@ -3497,6 +3840,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3513,6 +3857,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b671-cb4e-ed0a-7f97" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -3521,6 +3866,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="00d9-b41a-cdbc-a3a7" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -3529,6 +3875,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3545,6 +3892,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1962-2943-ccd6-534d" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -3560,6 +3908,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3567,9 +3916,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="039c-a3c5-412d-a575" name="Skeleton Archers [57 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="b088-fa94-5701-bcd5" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="d790-9b4d-a574-732f" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
@@ -3598,6 +3951,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="41c0-95ab-6847-5fa6" name="Skeleton Archer Leader" hidden="false" collective="false" type="model">
@@ -3611,6 +3965,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3618,6 +3973,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="00c5-20fd-2c3c-7b1f" name="Archers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -3634,6 +3990,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="35ff-f223-4db5-7ae8" name="Skeleton Archer Leader" hidden="false" collective="false" type="model">
@@ -3647,6 +4004,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3654,6 +4012,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3670,6 +4029,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0808-d599-69a9-d82f" name="Crossbow" hidden="false" collective="false" type="upgrade">
@@ -3685,6 +4045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3701,6 +4062,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6d37-9931-fa7b-fc8c" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -3716,6 +4078,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3723,9 +4086,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="72ae-4775-16bd-ddbe" name="Zombies [25]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="33cb-f07a-743e-e245" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>
@@ -3753,6 +4120,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3760,6 +4128,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="39af-0533-b2a2-c84e" name="Zombie (Upgraded to RES 6) (7 pts each)" hidden="false" collective="false" type="upgrade">
@@ -3776,6 +4145,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3783,6 +4153,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3790,9 +4161,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="33f0-db6e-95bb-d78e" name="Wights [102 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="7f8d-61aa-3d81-bb88" name="Spectral Undead" hidden="false" targetId="3dfb-f407-ff46-9b1f" type="rule"/>
         <infoLink id="92f4-3f81-9fc2-fa1d" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -3813,6 +4188,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e09-01da-cf4f-e23a" name="Wight Leader" hidden="false" collective="false" type="model">
@@ -3826,6 +4202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="38.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3842,6 +4219,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cce6-d9f2-8d75-17c2" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -3850,6 +4228,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="739e-5804-418c-0d2f" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -3858,6 +4237,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3880,6 +4260,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3887,9 +4268,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c5cd-75ca-cc12-0ac4" name="Skeleton Riders [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="67fd-480a-2e36-d781" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
         <infoLink id="7070-6832-01ef-c6b7" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
@@ -3918,6 +4303,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c990-b202-8ef3-5083" name="Skeleton Rider Leader" hidden="false" collective="false" type="model">
@@ -3931,6 +4317,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="38.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3938,6 +4325,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8115-2bde-b0c6-5235" name="Skeleton Riders in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -3954,6 +4342,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="31a8-4114-45fe-d577" name="Skeleton Rider Leader" hidden="false" collective="false" type="model">
@@ -3967,6 +4356,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="40.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3974,6 +4364,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3990,6 +4381,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c8e-17e6-da75-af56" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -3998,6 +4390,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b1b-8381-5aa4-0d75" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -4013,6 +4406,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4035,6 +4429,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4051,6 +4446,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbe9-602e-5e86-0b67" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4066,6 +4462,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4073,9 +4470,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3876-8378-f299-3c94" name="Skeleton Knights [102 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="820f-3f8e-fab6-dad8" name="Lance" hidden="false" targetId="e601-dcfc-7485-2164" type="profile"/>
         <infoLink id="92a8-908e-8165-b7ce" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
@@ -4098,6 +4499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="195e-b58e-5923-2b4a" name="Skeleton Knights" hidden="false" collective="false" type="model">
@@ -4110,6 +4512,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4126,6 +4529,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="52ad-fb00-6e8f-11f9" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4141,6 +4545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4148,9 +4553,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8f1c-6486-2c2b-8e30" name="Skeleton Chariot [117 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2bc4-d669-be6a-070e" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="aad5-aed8-b690-ddce" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
@@ -4173,6 +4582,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4191,6 +4601,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2da7-4f9f-e1a0-03b2" name="2x Helhorses  (HtH Attack SV1)" hidden="false" collective="false" type="upgrade">
@@ -4206,6 +4617,7 @@
                         <selectionEntry id="a493-a41f-bde2-d1f6" name="4x Helhorses" hidden="false" collective="false" type="upgrade">
                           <costs>
                             <cost name="pts" typeId="points" value="12.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -4213,6 +4625,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="12.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -4231,6 +4644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a97b-ad7c-4c3e-2f82" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4239,6 +4653,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4254,6 +4669,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4270,6 +4686,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="00c9-a1eb-7fb7-194e" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -4278,6 +4695,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7c1b-7ad2-a0b3-f3cf" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -4286,6 +4704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4308,6 +4727,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4324,6 +4744,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="107.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4331,9 +4752,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ff2a-d62f-8cd7-456d" name="Carrion Beast [153 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df3b-9e33-acc3-ff39" type="max"/>
       </constraints>
@@ -4361,6 +4786,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="153.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4386,6 +4812,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="2.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4402,6 +4829,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="95a6-266f-fb40-4620" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -4410,6 +4838,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8e13-1cad-e994-c3b4" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -4418,6 +4847,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4425,6 +4855,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4441,6 +4872,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f3a-7de2-1c85-d81b" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4449,6 +4881,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4456,9 +4889,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8d33-9051-6b4e-dfff" name="Skeleton Bolt Thrower [60 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="de6d-62f8-ee52-ad4a" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>
@@ -4486,6 +4923,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4493,6 +4931,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="038e-7662-b893-60c4" name="Skeleton Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -4509,6 +4948,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4516,6 +4956,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4539,6 +4980,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f92c-c6dd-f7df-ecf6" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -4547,6 +4989,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4563,6 +5006,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f18-7a90-9046-ba68" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -4571,6 +5015,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4587,6 +5032,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e835-7b09-a23d-e58e" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4602,6 +5048,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4619,6 +5066,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4626,9 +5074,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="302f-44fd-1451-bdb0" name="Skeleton Stone Thrower [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="a53d-ac12-d2cc-06a4" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
         <infoLink id="070c-7b9d-5397-5a0d" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
@@ -4657,6 +5109,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4664,6 +5117,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b110-b36f-7517-5d74" name="Skeleton Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -4680,6 +5134,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4687,6 +5142,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4710,6 +5166,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8115-bcf3-7161-84d1" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -4718,6 +5175,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4734,6 +5192,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2fa8-00d9-76a0-efc8" name="Large stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -4742,6 +5201,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4758,6 +5218,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7a86-35ee-07fc-2a61" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4773,6 +5234,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4788,6 +5250,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4804,6 +5267,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4811,6 +5275,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="cffa-cd51-33d5-b2c6" name="Warlords of Erehwon" revision="3" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="cffa-cd51-33d5-b2c6" name="Warlords of Erehwon" revision="4" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="cffa-cd51-pubN65537" name="WoE"/>
   </publications>
   <costTypes>
     <costType id="points" name="pts" defaultCostLimit="-1.0"/>
+    <costType id="6354-8c83-d4ad-3053" name=" order dice" defaultCostLimit="-1.0"/>
   </costTypes>
   <profileTypes>
     <profileType id="2f17-7b0c-7f4e-2baf" name="Model">
@@ -110,6 +111,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6ce7-b3cb-cc54-c24f" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -118,6 +120,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8041-8d76-f770-6872" name="Mace" hidden="false" collective="false" type="upgrade">
@@ -126,6 +129,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f1ad-8666-d5b5-021b" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -134,6 +138,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1689-c2e6-a3a5-4234" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -142,6 +147,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="83cf-506e-8f65-96e6" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -150,6 +156,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a419-3818-8175-2ebb" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -158,6 +165,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2826-f657-3cef-8c48" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -166,6 +174,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9e42-ba82-d1dc-30b1" name="Bow" hidden="false" collective="false" type="upgrade">
@@ -174,6 +183,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bd1d-fe59-12c3-dbb4" name="Longbow" hidden="false" collective="false" type="upgrade">
@@ -182,6 +192,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f757-c0e6-07f7-f84d" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -190,6 +201,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aa5c-b0e1-1af7-e32f" name="Spells" page="" hidden="false" collective="false" type="upgrade">
@@ -197,26 +209,31 @@
         <selectionEntry id="51b3-07a1-434a-388f" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9578-c92c-d9b9-a468" name="Chill Wind" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7f13-6bfa-a7d1-f1c0" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6fac-ec35-3592-0209" name="Endow Strength" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>


### PR DESCRIPTION
Adds order dice as a cost element to all units. Order dice are shown in the title for each section. No more manual counting, yay!